### PR TITLE
Update models nullable fields when not sent in API

### DIFF
--- a/src/Model/Department/Department.php
+++ b/src/Model/Department/Department.php
@@ -116,7 +116,7 @@ class Department extends BaseModel
     private $emails;
 
     /**
-     * @var array<mixed>
+     * @var array<mixed>|null
      * @SerializedName("groups")
      */
     private $groups;
@@ -476,18 +476,18 @@ class Department extends BaseModel
     }
 
     /**
-     * @return array<mixed>
+     * @return array<mixed>|null
      */
-    public function getGroups(): array
+    public function getGroups(): ?array
     {
         return $this->groups;
     }
 
     /**
-     * @param array<mixed> $groups
+     * @param array<mixed>|null $groups
      * @return self
      */
-    public function setGroups(array $groups): self
+    public function setGroups(?array $groups): self
     {
         $this->groups = $groups;
 

--- a/src/Model/SelfService/Article.php
+++ b/src/Model/SelfService/Article.php
@@ -135,7 +135,7 @@ class Article extends BaseModel
     private $views;
 
     /**
-     * @var Tag[]
+     * @var Tag[]|null
      */
     private $tags;
 
@@ -501,18 +501,18 @@ class Article extends BaseModel
     }
 
     /**
-     * @return Tag[]
-     */
-    public function getTags(): array
+     * @return Tag[]|null
+1     */
+    public function getTags(): ?array
     {
         return $this->tags;
     }
 
     /**
-     * @param Tag[] $tags
+     * @param Tag[]|null $tags
      * @return self
      */
-    public function setTags(array $tags): self
+    public function setTags(?array $tags): self
     {
         $this->tags = $tags;
 

--- a/src/Model/Ticket/Extra.php
+++ b/src/Model/Ticket/Extra.php
@@ -8,36 +8,36 @@ use Symfony\Component\Serializer\Annotation\SerializedName;
 class Extra extends BaseModel
 {
     /**
-     * @var array<mixed>
+     * @var string[]|null
      * @SerializedName("bcc_address")
      */
     private $bccAddress;
 
     /**
-     * @var array<mixed>
+     * @var string[]|null
      * @SerializedName("to_address")
      */
     private $toAddress;
 
     /**
-     * @var array<mixed>
+     * @var string[]|null
      * @SerializedName("cc_address")
      */
     private $ccAddress;
 
     /**
-     * @return array<mixed>
+     * @return string[]|null
      */
-    public function getBccAddress(): array
+    public function getBccAddress(): ?array
     {
         return $this->bccAddress;
     }
 
     /**
-     * @param array<mixed> $bccAddress
+     * @param string[]|null $bccAddress
      * @return self
      */
-    public function setBccAddress(array $bccAddress): self
+    public function setBccAddress(?array $bccAddress): self
     {
         $this->bccAddress = $bccAddress;
 
@@ -45,18 +45,18 @@ class Extra extends BaseModel
     }
 
     /**
-     * @return array<mixed>
+     * @return string[]|null
      */
-    public function getToAddress(): array
+    public function getToAddress(): ?array
     {
         return $this->toAddress;
     }
 
     /**
-     * @param array<mixed> $toAddress
+     * @param string[]|null $toAddress
      * @return self
      */
-    public function setToAddress(array $toAddress): self
+    public function setToAddress(?array $toAddress): self
     {
         $this->toAddress = $toAddress;
 
@@ -64,18 +64,18 @@ class Extra extends BaseModel
     }
 
     /**
-     * @return array<mixed>
+     * @return string[]|null
      */
-    public function getCcAddress(): array
+    public function getCcAddress(): ?array
     {
         return $this->ccAddress;
     }
 
     /**
-     * @param array<mixed> $ccAddress
+     * @param string[]|null $ccAddress
      * @return self
      */
-    public function setCcAddress(array $ccAddress): self
+    public function setCcAddress(?array $ccAddress): self
     {
         $this->ccAddress = $ccAddress;
 

--- a/src/Model/Ticket/Priority.php
+++ b/src/Model/Ticket/Priority.php
@@ -57,7 +57,7 @@ class Priority extends BaseModel
     private $iconWithoutTooltip;
 
     /**
-     * @var Department[]
+     * @var Department[]|null
      */
     private $departments;
 
@@ -214,18 +214,18 @@ class Priority extends BaseModel
     }
 
     /**
-     * @return Department[]
+     * @return Department[]|null
      */
-    public function getDepartments(): array
+    public function getDepartments(): ?array
     {
         return $this->departments;
     }
 
     /**
-     * @param Department[] $departments
+     * @param Department[]|null $departments
      * @return self
      */
-    public function setDepartments(array $departments): self
+    public function setDepartments(?array $departments): self
     {
         $this->departments = $departments;
 

--- a/src/Model/Ticket/Ticket.php
+++ b/src/Model/Ticket/Ticket.php
@@ -220,25 +220,25 @@ class Ticket extends BaseModel
     private $channelId;
 
     /**
-     * @var Channel
+     * @var Channel|null
      * @SerializedName("channel")
      */
     private $channel;
 
     /**
-     * @var Department
+     * @var Department|null
      * @SerializedName("department")
      */
     private $department;
 
     /**
-     * @var Tag[]
+     * @var Tag[]|null
      * @SerializedName("tags")
      */
     private $tags;
 
     /**
-     * @var User
+     * @var User|null
      * @SerializedName("user")
      */
     private $user;
@@ -250,19 +250,19 @@ class Ticket extends BaseModel
     private $token;
 
     /**
-     * @var Operator[]
+     * @var Operator[]|null
      * @SerializedName("watching")
      */
     private $watching;
 
     /**
-     * @var Operator[]
+     * @var Operator[]|null
      * @SerializedName("assigned")
      */
     private $assigned;
 
     /**
-     * @var Brand
+     * @var Brand|null
      * @SerializedName("brand")
      */
     private $brand;
@@ -280,19 +280,19 @@ class Ticket extends BaseModel
     private $slaplan;
 
     /**
-     * @var TicketCustomField[]
+     * @var TicketCustomField[]|null
      * @SerializedName("customfields")
      */
     private $customfields;
 
     /**
-     * @var Status
+     * @var Status|null
      * @SerializedName("status")
      */
     private $status;
 
     /**
-     * @var Priority
+     * @var Priority|null
      * @SerializedName("priority")
      */
     private $priority;
@@ -944,18 +944,18 @@ class Ticket extends BaseModel
     }
 
     /**
-     * @return Channel
+     * @return Channel|null
      */
-    public function getChannel(): Channel
+    public function getChannel(): ?Channel
     {
         return $this->channel;
     }
 
     /**
-     * @param Channel $channel
+     * @param Channel|null $channel
      * @return self
      */
-    public function setChannel(Channel $channel): self
+    public function setChannel(?Channel $channel): self
     {
         $this->channel = $channel;
 
@@ -963,18 +963,18 @@ class Ticket extends BaseModel
     }
 
     /**
-     * @return Department
+     * @return Department|null
      */
-    public function getDepartment(): Department
+    public function getDepartment(): ?Department
     {
         return $this->department;
     }
 
     /**
-     * @param Department $department
+     * @param Department|null $department
      * @return self
      */
-    public function setDepartment(Department $department): self
+    public function setDepartment(?Department $department): self
     {
         $this->department = $department;
 
@@ -982,18 +982,18 @@ class Ticket extends BaseModel
     }
 
     /**
-     * @return Tag[]
+     * @return Tag[]|null
      */
-    public function getTags(): array
+    public function getTags(): ?array
     {
         return $this->tags;
     }
 
     /**
-     * @param Tag[] $tags
+     * @param Tag[]|null $tags
      * @return self
      */
-    public function setTags(array $tags): self
+    public function setTags(?array $tags): self
     {
         $this->tags = $tags;
 
@@ -1001,18 +1001,18 @@ class Ticket extends BaseModel
     }
 
     /**
-     * @return User
+     * @return User|null
      */
-    public function getUser(): User
+    public function getUser(): ?User
     {
         return $this->user;
     }
 
     /**
-     * @param User $user
+     * @param User|null $user
      * @return self
      */
-    public function setUser(User $user): self
+    public function setUser(?User $user): self
     {
         $this->user = $user;
 
@@ -1039,18 +1039,18 @@ class Ticket extends BaseModel
     }
 
     /**
-     * @return Operator[]
+     * @return Operator[]|null
      */
-    public function getWatching(): array
+    public function getWatching(): ?array
     {
         return $this->watching;
     }
 
     /**
-     * @param Operator[] $watching
+     * @param Operator[]|null $watching
      * @return self
      */
-    public function setWatching(array $watching): self
+    public function setWatching(?array $watching): self
     {
         $this->watching = $watching;
 
@@ -1058,18 +1058,18 @@ class Ticket extends BaseModel
     }
 
     /**
-     * @return Operator[]
+     * @return Operator[]|null
      */
-    public function getAssigned(): array
+    public function getAssigned(): ?array
     {
         return $this->assigned;
     }
 
     /**
-     * @param Operator[] $assigned
+     * @param Operator[]|null $assigned
      * @return self
      */
-    public function setAssigned(array $assigned): self
+    public function setAssigned(?array $assigned): self
     {
         $this->assigned = $assigned;
 
@@ -1077,18 +1077,18 @@ class Ticket extends BaseModel
     }
 
     /**
-     * @return Brand
+     * @return Brand|null
      */
-    public function getBrand(): Brand
+    public function getBrand(): ?Brand
     {
         return $this->brand;
     }
 
     /**
-     * @param Brand $brand
+     * @param Brand|null $brand
      * @return self
      */
-    public function setBrand(Brand $brand): self
+    public function setBrand(?Brand $brand): self
     {
         $this->brand = $brand;
 
@@ -1134,18 +1134,18 @@ class Ticket extends BaseModel
     }
 
     /**
-     * @return TicketCustomField[]
+     * @return TicketCustomField[]|null
      */
-    public function getCustomfields(): array
+    public function getCustomfields(): ?array
     {
         return $this->customfields;
     }
 
     /**
-     * @param TicketCustomField[] $customfields
+     * @param TicketCustomField[]|null $customfields
      * @return self
      */
-    public function setCustomfields(array $customfields): self
+    public function setCustomfields(?array $customfields): self
     {
         $this->customfields = $customfields;
 
@@ -1153,18 +1153,18 @@ class Ticket extends BaseModel
     }
 
     /**
-     * @return Status
+     * @return Status|null
      */
-    public function getStatus(): Status
+    public function getStatus(): ?Status
     {
         return $this->status;
     }
 
     /**
-     * @param Status $status
+     * @param Status|null $status
      * @return self
      */
-    public function setStatus(Status $status): self
+    public function setStatus(?Status $status): self
     {
         $this->status = $status;
 
@@ -1172,18 +1172,18 @@ class Ticket extends BaseModel
     }
 
     /**
-     * @return Priority
+     * @return Priority|null
      */
-    public function getPriority(): Priority
+    public function getPriority(): ?Priority
     {
         return $this->priority;
     }
 
     /**
-     * @param Priority $priority
+     * @param Priority|null $priority
      * @return self
      */
-    public function setPriority(Priority $priority): self
+    public function setPriority(?Priority $priority): self
     {
         $this->priority = $priority;
 

--- a/src/Model/User/Organisation.php
+++ b/src/Model/User/Organisation.php
@@ -68,19 +68,19 @@ class Organisation extends BaseModel
     private $ownerId;
 
     /**
-     * @var User[]
+     * @var User[]|null
      * @SerializedName("users")
      */
     private $users;
 
     /**
-     * @var UserCustomField[]
+     * @var UserCustomField[]|null
      * @SerializedName("customfields")
      */
     private $customfields;
 
     /**
-     * @var Domain[]
+     * @var Domain[]|null
      * @SerializedName("domains")
      */
     private $domains;
@@ -276,18 +276,18 @@ class Organisation extends BaseModel
     }
 
     /**
-     * @return User[]
+     * @return User[]|null
      */
-    public function getUsers(): array
+    public function getUsers(): ?array
     {
         return $this->users;
     }
 
     /**
-     * @param User[] $users
+     * @param User[]|null $users
      * @return Organisation
      */
-    public function setUsers(array $users): Organisation
+    public function setUsers(?array $users): Organisation
     {
         $this->users = $users;
 
@@ -295,18 +295,18 @@ class Organisation extends BaseModel
     }
 
     /**
-     * @return UserCustomField[]
+     * @return UserCustomField[]|null
      */
-    public function getCustomfields(): array
+    public function getCustomfields(): ?array
     {
         return $this->customfields;
     }
 
     /**
-     * @param UserCustomField[] $customfields
+     * @param UserCustomField[]|null $customfields
      * @return Organisation
      */
-    public function setCustomfields(array $customfields): Organisation
+    public function setCustomfields(?array $customfields): Organisation
     {
         $this->customfields = $customfields;
 
@@ -314,18 +314,18 @@ class Organisation extends BaseModel
     }
 
     /**
-     * @return Domain[]
+     * @return Domain[]|null
      */
-    public function getDomains(): array
+    public function getDomains(): ?array
     {
         return $this->domains;
     }
 
     /**
-     * @param Domain[] $domains
+     * @param Domain[]|null $domains
      * @return Organisation
      */
-    public function setDomains(array $domains): Organisation
+    public function setDomains(?array $domains): Organisation
     {
         $this->domains = $domains;
 

--- a/src/Model/User/User.php
+++ b/src/Model/User/User.php
@@ -26,7 +26,7 @@ class User extends BaseModel
     private $avatar;
 
     /**
-     * @var int
+     * @var int|null
      * @SerializedName("twofa_enabled")
      */
     private $twofaEnabled;
@@ -189,7 +189,7 @@ class User extends BaseModel
     private $customfields;
 
     /**
-     * @var Group[]
+     * @var Group[]|null
      * @SerializedName("groups")
      */
     private $groups;
@@ -632,18 +632,18 @@ class User extends BaseModel
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getTwofaEnabled(): int
+    public function getTwofaEnabled(): ?int
     {
         return $this->twofaEnabled;
     }
 
     /**
-     * @param int $twofaEnabled
+     * @param int|null $twofaEnabled
      * @return self
      */
-    public function setTwofaEnabled(int $twofaEnabled): self
+    public function setTwofaEnabled(?int $twofaEnabled): self
     {
         $this->twofaEnabled = $twofaEnabled;
 
@@ -765,18 +765,18 @@ class User extends BaseModel
     }
 
     /**
-     * @return Group[]
+     * @return Group[]|null
      */
-    public function getGroups(): array
+    public function getGroups(): ?array
     {
         return $this->groups;
     }
 
     /**
-     * @param Group[] $groups
+     * @param Group[]|null $groups
      * @return self
      */
-    public function setGroups(array $groups): self
+    public function setGroups(?array $groups): self
     {
         $this->groups = $groups;
 


### PR DESCRIPTION
Those fields are null when being sent under relations, but generally not null when sent in the main API.

i.e: calling `tickets/tickets` - `Ticket -> Department` groups fields would be null ( not returned at all)
