### PR TITLE
fix: #33 - added exception message

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -68,7 +68,7 @@ class ApiClient
             $response = $this->getHttpClient()->sendRequest($request);
             $this->assertRequestSuccessful($response);
         } catch (ClientExceptionInterface $exception) {
-            throw new HttpResponseException;
+            throw new HttpResponseException($exception->getMessage(), 0, $exception);
         }
 
         return $response;


### PR DESCRIPTION
Added GuzzleHttp exception to `HttpResponseException`, otherwise it's not possible to access this information and it's difficult to debug connection errors.

Closes #33 