### PR TITLE
Fix: #38, 37 Update api prefix handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,6 @@ jobs:
 
             - name: Execute Integration tests
               run: TESTSUITE=integration MINCOVERAGE=85 ci/test.sh
+
+            - name: Execute Cache tests
+              run: ./vendor/bin/phpunit --testsuite=cache --stop-on-fail

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,9 @@
         <testsuite name="e2e">
             <directory>test/E2E</directory>
         </testsuite>
+        <testsuite name="cache">
+            <directory>test/cache</directory>
+        </testsuite>
     </testsuites>
 
     <filter>

--- a/src/Cache/ApiCacheMap.php
+++ b/src/Cache/ApiCacheMap.php
@@ -19,7 +19,7 @@ class ApiCacheMap
      * Should not add duplicate entries in sub-arrays.
      * Duplicate entry will use the first occurring cache_ttl
      */
-    private const CACHE_MAP = [
+    protected const CACHE_MAP = [
         self::DEFAULT_CACHE_TTL => [
             ApiDictionary::CORE_SETTINGS,
             ApiDictionary::SELF_SERVICE_SETTINGS,
@@ -34,12 +34,12 @@ class ApiCacheMap
 
     /**
      * @param string $baseUrl
-     * @return array<int, array<int, string>>
+     * @return array<int|string, array<int, string>>
      */
     public function getCacheableApis(string $baseUrl): array
     {
         $cacheableApis = [];
-        foreach (self::CACHE_MAP as $ttl => $apis) {
+        foreach (static::CACHE_MAP as $ttl => $apis) {
             $cacheableApis[$ttl] = [];
             foreach ($apis as $key => $api) {
                 $apiUri = $baseUrl . ltrim($api, '/');

--- a/src/Cache/ApiCacheMap.php
+++ b/src/Cache/ApiCacheMap.php
@@ -4,12 +4,14 @@ namespace SupportPal\ApiClient\Cache;
 
 use SupportPal\ApiClient\Dictionary\ApiDictionary;
 
+use function ltrim;
+
 /**
  * This class includes the list of cachable apis related to their behaviour
  * Class ApiCacheMap
  * @package SupportPal\ApiClient\Cache
  */
-final class ApiCacheMap
+class ApiCacheMap
 {
     private const DEFAULT_CACHE_TTL = 600;
 
@@ -17,16 +19,34 @@ final class ApiCacheMap
      * Should not add duplicate entries in sub-arrays.
      * Duplicate entry will use the first occurring cache_ttl
      */
-    public const CACHE_MAP = [
+    private const CACHE_MAP = [
         self::DEFAULT_CACHE_TTL => [
-            ApiDictionary::CORE_SETTINGS => 'GET',
-            ApiDictionary::SELF_SERVICE_SETTINGS => 'GET',
-            ApiDictionary::SELF_SERVICE_ARTICLE => 'GET',
-            ApiDictionary::SELF_SERVICE_ARTICLE_TYPE => 'GET',
-            ApiDictionary::SELF_SERVICE_CATEGORY => 'GET',
-            ApiDictionary::SELF_SERVICE_TAG => 'GET',
-            ApiDictionary::SELF_SERVICE_ARTICLE_SEARCH => 'GET',
-            ApiDictionary::SELF_SERVICE_COMMENT => 'GET',
+            ApiDictionary::CORE_SETTINGS,
+            ApiDictionary::SELF_SERVICE_SETTINGS,
+            ApiDictionary::SELF_SERVICE_ARTICLE,
+            ApiDictionary::SELF_SERVICE_ARTICLE_TYPE,
+            ApiDictionary::SELF_SERVICE_CATEGORY,
+            ApiDictionary::SELF_SERVICE_TAG,
+            ApiDictionary::SELF_SERVICE_ARTICLE_SEARCH,
+            ApiDictionary::SELF_SERVICE_COMMENT,
         ],
     ];
+
+    /**
+     * @param string $baseUrl
+     * @return array<int, array<int, string>>
+     */
+    public function getCacheableApis(string $baseUrl): array
+    {
+        $cacheableApis = [];
+        foreach (self::CACHE_MAP as $ttl => $apis) {
+            $cacheableApis[$ttl] = [];
+            foreach ($apis as $key => $api) {
+                $apiUri = $baseUrl . ltrim($api, '/');
+                $cacheableApis[$ttl][] = $apiUri;
+            }
+        }
+
+        return $cacheableApis;
+    }
 }

--- a/src/Cache/CacheStrategyConfigurator.php
+++ b/src/Cache/CacheStrategyConfigurator.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace SupportPal\ApiClient\Cache;
+
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\ChainCache;
+use Doctrine\Common\Cache\FilesystemCache;
+use Kevinrob\GuzzleCache\Storage\DoctrineCacheStorage;
+use Kevinrob\GuzzleCache\Strategy\CacheStrategyInterface;
+use Kevinrob\GuzzleCache\Strategy\Delegate\DelegatingCacheStrategy;
+use Kevinrob\GuzzleCache\Strategy\GreedyCacheStrategy;
+use Kevinrob\GuzzleCache\Strategy\NullCacheStrategy;
+
+class CacheStrategyConfigurator
+{
+    /** @var ApiCacheMap */
+    private $apiCacheMap;
+
+    public function __construct(ApiCacheMap $apiCacheMap)
+    {
+        $this->apiCacheMap = $apiCacheMap;
+    }
+
+    /**
+     * This function sets the cache strategy used in the application.
+     * By default, endpoints will not be cached unless specified per path, per method.
+     * We also use two types of cache, ArrayCache, and FileSystem cache sorted from faster to slower.
+     * We always use a greedy strategy (ignore headers returned by the server)
+     *
+     * read more @https://github.com/Kevinrob/guzzle-cache-middleware
+     * @param string $cacheDir
+     * @param string $baseApiPath
+     * @return CacheStrategyInterface
+     */
+    public function buildCacheStrategy(string $cacheDir, string $baseApiPath): CacheStrategyInterface
+    {
+        $delegatingCacheStrategy = new DelegatingCacheStrategy(new NullCacheStrategy);
+        /**
+         * For every set of Apis, clustered by a default TTL, we create a cache storage.
+         */
+        foreach ($this->apiCacheMap->getCacheableApis($baseApiPath) as $ttl => $apis) {
+            $cacheStorage = new DoctrineCacheStorage(new ChainCache([new ArrayCache, new FilesystemCache($cacheDir)]));
+            $cacheStrategy = new GreedyCacheStrategy($cacheStorage, $ttl);
+            /**
+             * request matcher handlers linking the caching strategy to every specific endpoint
+             */
+            $delegatingCacheStrategy->registerRequestMatcher(new CacheableRequestMatcher($apis), $cacheStrategy);
+        }
+
+        return $delegatingCacheStrategy;
+    }
+}

--- a/src/Cache/CacheableRequestMatcher.php
+++ b/src/Cache/CacheableRequestMatcher.php
@@ -5,6 +5,8 @@ namespace SupportPal\ApiClient\Cache;
 use Kevinrob\GuzzleCache\Strategy\Delegate\RequestMatcherInterface;
 use Psr\Http\Message\RequestInterface;
 
+use function strpos;
+
 class CacheableRequestMatcher implements RequestMatcherInterface
 {
     /** @var array<int, string> */
@@ -25,7 +27,7 @@ class CacheableRequestMatcher implements RequestMatcherInterface
     public function matches(RequestInterface $request)
     {
         foreach ($this->cachableApis as $path) {
-            if ($request->getUri()->getPath() === $path && $request->getMethod() === 'GET') {
+            if (strpos($request->getUri()->getPath(), $path) !== false && $request->getMethod() === 'GET') {
                 return true;
             }
         }

--- a/src/Cache/CacheableRequestMatcher.php
+++ b/src/Cache/CacheableRequestMatcher.php
@@ -7,12 +7,12 @@ use Psr\Http\Message\RequestInterface;
 
 class CacheableRequestMatcher implements RequestMatcherInterface
 {
-    /** @var array<string, string> */
+    /** @var array<int, string> */
     private $cachableApis;
 
     /**
      * CacheableRequestMatcher constructor.
-     * @param array<string, string> $cachableApis
+     * @param array<int, string> $cachableApis
      */
     public function __construct(array $cachableApis)
     {
@@ -24,8 +24,8 @@ class CacheableRequestMatcher implements RequestMatcherInterface
      */
     public function matches(RequestInterface $request)
     {
-        foreach ($this->cachableApis as $path => $method) {
-            if ($request->getUri()->getPath() === $path && $request->getMethod() === $method) {
+        foreach ($this->cachableApis as $path) {
+            if ($request->getUri()->getPath() === $path && $request->getMethod() === 'GET') {
                 return true;
             }
         }

--- a/src/Dictionary/ApiDictionary.php
+++ b/src/Dictionary/ApiDictionary.php
@@ -3,7 +3,8 @@
 namespace SupportPal\ApiClient\Dictionary;
 
 /**
- * This class includes the names of all the supported endpoints
+ * This class includes the names of all the supported endpoints.
+ * The defined APIs should only include the resource path without the API `/` prefix and postfix.
  * Class APIDictionary
  * @package SupportPal\ApiClient\Dictionary
  */

--- a/test/Cache/CacheableApisTest.php
+++ b/test/Cache/CacheableApisTest.php
@@ -1,0 +1,254 @@
+<?php declare(strict_types=1);
+
+namespace SupportPal\ApiClient\Tests\Cache;
+
+use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Kevinrob\GuzzleCache\CacheMiddleware;
+use Kevinrob\GuzzleCache\Strategy\CacheStrategyInterface;
+use SupportPal\ApiClient\ApiClient;
+use SupportPal\ApiClient\Cache\ApiCacheMap;
+use SupportPal\ApiClient\Cache\CacheStrategyConfigurator;
+use SupportPal\ApiClient\Dictionary\ApiDictionary;
+use SupportPal\ApiClient\Tests\ContainerAwareBaseTestCase;
+use SupportPal\ApiClient\Tests\DataFixtures\Core\CoreSettingsData;
+use SupportPal\ApiClient\Tests\DataFixtures\SelfService\ArticleData;
+use SupportPal\ApiClient\Tests\DataFixtures\SelfService\CategoryData;
+use SupportPal\ApiClient\Tests\DataFixtures\SelfService\CommentData;
+use SupportPal\ApiClient\Tests\DataFixtures\SelfService\SettingsData;
+use SupportPal\ApiClient\Tests\DataFixtures\SelfService\TagData;
+use SupportPal\ApiClient\Tests\DataFixtures\SelfService\TypeData;
+use SupportPal\ApiClient\Tests\DataFixtures\Ticket\AttachmentData;
+use SupportPal\ApiClient\Tests\DataFixtures\Ticket\ChannelSettingsData;
+use SupportPal\ApiClient\Tests\DataFixtures\Ticket\DepartmentData;
+use SupportPal\ApiClient\Tests\DataFixtures\Ticket\MessageData;
+use SupportPal\ApiClient\Tests\DataFixtures\Ticket\PriorityData;
+use SupportPal\ApiClient\Tests\DataFixtures\Ticket\StatusData;
+use SupportPal\ApiClient\Tests\DataFixtures\Ticket\TicketCustomFieldData;
+use SupportPal\ApiClient\Tests\DataFixtures\Ticket\TicketData;
+use SupportPal\ApiClient\Tests\DataFixtures\User\UserData;
+
+use function call_user_func_array;
+use function sleep;
+use function sys_get_temp_dir;
+
+class CacheableApisTest extends ContainerAwareBaseTestCase
+{
+    protected const BASE_API_PATH = '/api/';
+
+    /**
+     * @param string $endpoint
+     * @param array<mixed> $data
+     * @param array<mixed> $parameters
+     * @throws Exception
+     * @dataProvider provideCacheableApiCalls
+     */
+    public function testGetCacheableApiTestCacheHit(string $endpoint, array $data, array $parameters): void
+    {
+        /** @var ApiClient $apiClient */
+        $apiClient = $this->getContainer()->get(ApiClient::class);
+
+        $response = new Response(200, [], (string) $this->getEncoder()->encode($data, $this->getFormatType()));
+        $response2 = new Response(200, [], (string) $this->getEncoder()->encode($data, $this->getFormatType()));
+
+        $this->mockRequestHandler->append($response);
+        $this->mockRequestHandler->append($response2);
+
+        /** @var callable $callable */
+        $callable = [$apiClient, $endpoint];
+        $response1 = call_user_func_array($callable, $parameters);
+        $response2 = call_user_func_array($callable, $parameters);
+
+
+        $this->assertEquals(
+            CacheMiddleware::HEADER_CACHE_MISS,
+            $response1->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO)
+        );
+
+        $this->assertEquals(
+            CacheMiddleware::HEADER_CACHE_HIT,
+            $response2->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO)
+        );
+    }
+
+    /**
+     * @param string $endpoint
+     * @param array<mixed> $data
+     * @param array<mixed> $parameters
+     * @throws Exception
+     * @dataProvider provideCacheableApiCalls
+     */
+    public function testGetCacheableApiTestCacheMiss(string $endpoint, array $data, array $parameters): void
+    {
+        /** @var ApiClient $apiClient */
+        $apiClient = $this->getContainer()->get(ApiClient::class);
+
+        $response = new Response(200, [], (string) $this->getEncoder()->encode($data, $this->getFormatType()));
+        $response2 = new Response(200, [], (string) $this->getEncoder()->encode($data, $this->getFormatType()));
+
+        $this->mockRequestHandler->append($response);
+        $this->mockRequestHandler->append($response2);
+
+        /** @var callable $callable */
+        $callable = [$apiClient, $endpoint];
+        $response1 = call_user_func_array($callable, $parameters);
+        sleep(1);
+        $response2 = call_user_func_array($callable, $parameters);
+
+
+        $this->assertEquals(
+            CacheMiddleware::HEADER_CACHE_MISS,
+            $response1->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO)
+        );
+
+        $this->assertEquals(
+            CacheMiddleware::HEADER_CACHE_HIT,
+            $response2->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO)
+        );
+    }
+
+    /**
+     * @param string $endpoint
+     * @param array<mixed> $data
+     * @param array<mixed> $parameters
+     * @throws Exception
+     * @dataProvider provideNonCacheableApis
+     */
+    public function testNonCacheableApisAlwaysMiss(string $endpoint, array $data, array $parameters): void
+    {
+        /** @var ApiClient $apiClient */
+        $apiClient = $this->getContainer()->get(ApiClient::class);
+
+        $response = new Response(200, [], (string) $this->getEncoder()->encode($data, $this->getFormatType()));
+        $response2 = new Response(200, [], (string) $this->getEncoder()->encode($data, $this->getFormatType()));
+
+        $this->mockRequestHandler->append($response);
+        $this->mockRequestHandler->append($response2);
+
+        /** @var callable $callable */
+        $callable = [$apiClient, $endpoint];
+        $response1 = call_user_func_array($callable, $parameters);
+        $response2 = call_user_func_array($callable, $parameters);
+
+
+        $this->assertEquals(
+            CacheMiddleware::HEADER_CACHE_MISS,
+            $response1->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO)
+        );
+
+        $this->assertEquals(
+            CacheMiddleware::HEADER_CACHE_MISS,
+            $response2->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        /**
+         * A sleep period to invalidate cache after the teardown of every test.
+         * This eliminates the possibility of instability with subsequent tests
+         */
+        sleep(1);
+    }
+
+    /**
+     * @return iterable<mixed>
+     */
+    public function provideCacheableApiCalls(): iterable
+    {
+        $typeData = new TypeData;
+        $commentData = new CommentData;
+        $settingsData = new SettingsData;
+        $categoryData = new CategoryData;
+        $articleData = new ArticleData;
+        $tagData = new TagData;
+
+        yield ['getCoreSettings' ,(new CoreSettingsData)->getResponse(), []];
+        yield ['getCategories' ,$categoryData->getAllResponse(), [[]]];
+        yield ['getCategory' ,$categoryData->getResponse(), [1]];
+        yield ['getArticle' ,$articleData->getResponse(), [1, []]];
+        yield ['getTag' ,$tagData->getResponse(), [1]];
+        yield ['getArticles' ,$articleData->getAllResponse(), [[]]];
+        yield ['getSelfServiceSettings' ,$settingsData->getResponse(), []];
+        yield ['getComments' ,$commentData->getAllResponse(), [[]]];
+        yield ['getTypes' ,$typeData->getAllResponse(), [[]]];
+    }
+
+    /**
+     * @return iterable<mixed>
+     */
+    public function provideNonCacheableApis(): iterable
+    {
+        $departmentData = new DepartmentData;
+        $settingsData = new \SupportPal\ApiClient\Tests\DataFixtures\Ticket\SettingsData;
+        $channelSettingsData = new ChannelSettingsData;
+        $ticketCustomFieldData = new TicketCustomFieldData;
+        $priorityData = new PriorityData;
+        $statusData = new StatusData;
+        $attachmentData = new AttachmentData;
+        $ticketData = new TicketData;
+        $messageData = new MessageData;
+        $userData = new UserData;
+
+        yield ['getDepartments', $departmentData->getAllResponse(), [[]]];
+        yield ['getDepartment', $departmentData->getResponse(), [1]];
+        yield ['getTicketSettings', $settingsData->getResponse(), []];
+        yield ['getChannelSettings', $channelSettingsData->getResponse(), ['web']];
+        yield ['getTicketCustomFields', $ticketCustomFieldData->getAllResponse(), [[]]];
+        yield ['getTicketPriorities', $priorityData->getAllResponse(), [[]]];
+        yield ['getTicketPriority', $statusData->getResponse(), [1]];
+        yield ['getTicketStatuses', $statusData->getAllResponse(), [[]]];
+        yield ['getTicketStatus', $statusData->getResponse(), [1]];
+        yield ['getTicketAttachments', $attachmentData->getAllResponse(), [[]]];
+        yield ['getTicketAttachment', $attachmentData->getResponse(), [1]];
+        yield ['getTickets', $ticketData->getAllResponse(), [[]]];
+        yield ['getTicket', $ticketData->getResponse(), [1]];
+        yield ['getTicketMessage', $messageData->getResponse(), [1]];
+        yield ['getTicketMessages', $messageData->getAllResponse(), [[]]];
+        yield ['getUsers', $userData->getAllResponse(), [[]]];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getGuzzleClient(): Client
+    {
+        /**
+         * replace GuzzleClient with MockClient
+         */
+        $this->mockRequestHandler = new MockHandler;
+        $handlerStack = HandlerStack::create($this->mockRequestHandler);
+        $handlerStack->push(new CacheMiddleware($this->buildCacheStrategy(sys_get_temp_dir())));
+
+        return new Client(['handler' => $handlerStack]);
+    }
+
+    /**
+     * @param string $cacheDir
+     * @return CacheStrategyInterface
+     */
+    private function buildCacheStrategy(string $cacheDir): CacheStrategyInterface
+    {
+        $apiCacheMap = new class extends ApiCacheMap {
+            protected const CACHE_MAP = [
+                1 => [
+                    ApiDictionary::CORE_SETTINGS,
+                    ApiDictionary::SELF_SERVICE_SETTINGS,
+                    ApiDictionary::SELF_SERVICE_ARTICLE,
+                    ApiDictionary::SELF_SERVICE_ARTICLE_TYPE,
+                    ApiDictionary::SELF_SERVICE_CATEGORY,
+                    ApiDictionary::SELF_SERVICE_TAG,
+                    ApiDictionary::SELF_SERVICE_ARTICLE_SEARCH,
+                    ApiDictionary::SELF_SERVICE_COMMENT,
+                ],
+            ];
+        };
+
+        return (new CacheStrategyConfigurator($apiCacheMap))
+            ->buildCacheStrategy($cacheDir, self::BASE_API_PATH);
+    }
+}

--- a/test/ContainerAwareBaseTestCase.php
+++ b/test/ContainerAwareBaseTestCase.php
@@ -42,7 +42,7 @@ abstract class ContainerAwareBaseTestCase extends TestCase
     private $container;
 
     /** @var MockHandler */
-    private $mockRequestHandler;
+    protected $mockRequestHandler;
 
     /**
      * @return iterable<array<string, Response>>
@@ -85,13 +85,7 @@ abstract class ContainerAwareBaseTestCase extends TestCase
         $containerBuilder = new ContainerBuilder;
         $loader = new YamlFileLoader($containerBuilder, new FileLocator(__DIR__));
         $loader->load('Resources/services_test.yml');
-
-        /**
-         * replace GuzzleClient with MockClient
-         */
-        $this->mockRequestHandler = new MockHandler;
-        $handlerStack = HandlerStack::create($this->mockRequestHandler);
-        $client = new Client(['handler' => $handlerStack]);
+        $client = $this->getGuzzleClient();
         $containerBuilder->set('GuzzleHttp\Client', $client);
         $containerBuilder->compile();
 
@@ -184,5 +178,19 @@ abstract class ContainerAwareBaseTestCase extends TestCase
         self::expectExceptionMessage(
             $this->getDecoder()->decode((string) $response->getBody(), $this->getFormatType())['message']
         );
+    }
+
+    /**
+     * @return Client
+     */
+    protected function getGuzzleClient(): Client
+    {
+        /**
+         * replace GuzzleClient with MockClient
+         */
+        $this->mockRequestHandler = new MockHandler;
+        $handlerStack = HandlerStack::create($this->mockRequestHandler);
+
+        return new Client(['handler' => $handlerStack]);
     }
 }

--- a/test/Functional/Api/Cache/CacheableApisTest.php
+++ b/test/Functional/Api/Cache/CacheableApisTest.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace SupportPal\ApiClient\Tests\Functional\Api\Cache;
+
+use SupportPal\ApiClient\Tests\ContainerAwareBaseTestCase;
+
+class CacheableApisTest extends ContainerAwareBaseTestCase
+{
+}

--- a/test/Integration/Factory/RequestFactoryTest.php
+++ b/test/Integration/Factory/RequestFactoryTest.php
@@ -71,6 +71,7 @@ class RequestFactoryTest extends ContainerAwareBaseTestCase
 
         $headersArray['Authorization'] = ['Basic ' . base64_encode($this->apiToken . ':X')];
         $headersArray['Content-Type'] = [$this->apiContentType];
+        $headersArray['Host'] = [$request->getUri()->getHost() . ':' . $request->getUri()->getPort()];
 
         $encodedBody = ! empty($data['body']) || ! empty($this->defaultBodyContent)
             ? $this->getEncoder()->encode(array_merge($data['body'], $this->defaultBodyContent), $this->getFormatType())
@@ -78,7 +79,7 @@ class RequestFactoryTest extends ContainerAwareBaseTestCase
 
         self::assertInstanceOf(Request::class, $request);
         self::assertSame($data['method'], $request->getMethod());
-        self::assertSame($this->apiUrl . $data['endpoint'], $request->getUri()->getPath());
+        self::assertStringContainsString($data['endpoint'], $request->getUri()->getPath());
         self::assertSame($encodedBody, $request->getBody()->getContents());
         self::assertEquals($headersArray, $request->getHeaders());
         self::assertSame(

--- a/test/Integration/Factory/RequestFactoryTest.php
+++ b/test/Integration/Factory/RequestFactoryTest.php
@@ -22,9 +22,6 @@ class RequestFactoryTest extends ContainerAwareBaseTestCase
     private $requestFactory;
 
     /** @var string */
-    private $apiUrl;
-
-    /** @var string */
     private $apiToken;
 
     /** @var string */
@@ -43,7 +40,6 @@ class RequestFactoryTest extends ContainerAwareBaseTestCase
         $requestFactory = $this->getContainer()->get(RequestFactory::class);
         $this->requestFactory = $requestFactory;
         $this->apiToken = $this->getContainer()->getParameter('apiToken');
-        $this->apiUrl = $this->getContainer()->getParameter('apiUrl');
         $this->apiContentType = $this->getContainer()->getParameter('apiContentType');
         $this->defaultBodyContent = $this->getContainer()->getParameter('defaultBodyContent');
         $this->defaultParameters = $this->getContainer()->getParameter('defaultParameters');

--- a/test/Resources/services_test.yml
+++ b/test/Resources/services_test.yml
@@ -2,7 +2,7 @@ imports:
     - { resource: ../../src/Resources/services.yml }
 
 parameters:
-    apiUrl: 'test1'
+    apiUrl: 'localhost:8080/api/'
     apiToken: 'test2'
     apiContentType: 'test3'
     contentType: 'json'

--- a/test/Unit/Cache/ApiCacheMapTest.php
+++ b/test/Unit/Cache/ApiCacheMapTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace SupportPal\ApiClient\Tests\Unit\Cache;
+
+use SupportPal\ApiClient\Cache\ApiCacheMap;
+use SupportPal\ApiClient\Tests\TestCase;
+
+class ApiCacheMapTest extends TestCase
+{
+    /** @var ApiCacheMap */
+    private $apiCacheMap;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->apiCacheMap = new ApiCacheMap;
+    }
+
+    public function testGetCacheableApis(): void
+    {
+        $cacheableApis = $this->apiCacheMap->getCacheableApis('/api/');
+        foreach ($cacheableApis as $ttl => $apis) {
+            $this->assertIsInt($ttl);
+            foreach ($apis as $api) {
+                $this->assertStringNotContainsString('//', $api);
+            }
+        }
+    }
+}

--- a/test/Unit/Cache/CacheStrategyConfiguratorTest.php
+++ b/test/Unit/Cache/CacheStrategyConfiguratorTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace SupportPal\ApiClient\Tests\Unit\Cache;
+
+use Kevinrob\GuzzleCache\Strategy\CacheStrategyInterface;
+use Prophecy\Prophecy\ObjectProphecy;
+use SupportPal\ApiClient\Cache\ApiCacheMap;
+use SupportPal\ApiClient\Cache\CacheStrategyConfigurator;
+use SupportPal\ApiClient\Tests\TestCase;
+
+use function sys_get_temp_dir;
+
+/**
+ * Class CacheStrategyConfiguratorTest
+ * @package SupportPal\ApiClient\Tests\Unit\Cache
+ * @covers \SupportPal\ApiClient\Cache\CacheStrategyConfigurator
+ */
+class CacheStrategyConfiguratorTest extends TestCase
+{
+    /** @var ObjectProphecy */
+    private $apiCacheMap;
+
+    /** @var CacheStrategyConfigurator */
+    private $cacheConfigurator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->apiCacheMap = $this->prophesize(ApiCacheMap::class);
+
+        /** @var ApiCacheMap $apiCacheMap */
+        $apiCacheMap = $this->apiCacheMap->reveal();
+        $this->cacheConfigurator = new CacheStrategyConfigurator($apiCacheMap);
+    }
+
+    public function testConfigureCache(): void
+    {
+        $this->apiCacheMap->getCacheableApis('/api/')->shouldBeCalled();
+        $strategy = $this->cacheConfigurator->buildCacheStrategy(sys_get_temp_dir(), '/api/');
+        $this->assertInstanceOf(CacheStrategyInterface::class, $strategy);
+    }
+}

--- a/test/Unit/Cache/CacheableRequestMatcherTest.php
+++ b/test/Unit/Cache/CacheableRequestMatcherTest.php
@@ -22,7 +22,7 @@ class CacheableRequestMatcherTest extends TestCase
     {
         parent::setUp();
         $this->cacheableRequestMatcher = new CacheableRequestMatcher([
-            ApiDictionary::CORE_SETTINGS => 'GET'
+            ApiDictionary::CORE_SETTINGS
         ]);
     }
 


### PR DESCRIPTION
The fix offloads handling the BASE url to only the single added const. 