### PR TITLE
feat: added new ssl methods

### DIFF
--- a/src/Config/ApiContext.php
+++ b/src/Config/ApiContext.php
@@ -62,7 +62,7 @@ class ApiContext
      */
     public function getApiPath(): string
     {
-        return sprintf('/%s/%s', $this->trim($this->path), self::BASE_API_PATH);
+        return '/' . $this->trim(sprintf('/%s/%s', $this->trim($this->path), self::BASE_API_PATH)) . '/';
     }
 
     /**
@@ -72,8 +72,8 @@ class ApiContext
      */
     public function enableSsl(): self
     {
-        $this->scheme = 'https';
-        $this->port = 443;
+        $this->setScheme('https');
+        $this->setPort(443);
 
         return $this;
     }
@@ -85,8 +85,8 @@ class ApiContext
      */
     public function disableSsl(): self
     {
-        $this->scheme = 'http';
-        $this->port = 80;
+        $this->setScheme('http');
+        $this->setPort(80);
 
         return $this;
     }

--- a/src/Config/ApiContext.php
+++ b/src/Config/ApiContext.php
@@ -66,6 +66,32 @@ class ApiContext
     }
 
     /**
+     * Use a secure connection over SSL/TLS.
+     *
+     * @return $this
+     */
+    public function enableSsl(): self
+    {
+        $this->scheme = 'https';
+        $this->port = 443;
+
+        return $this;
+    }
+
+    /**
+     * Use an in-secure connection to the API.
+     *
+     * @return $this
+     */
+    public function disableSsl(): self
+    {
+        $this->scheme = 'http';
+        $this->port = 80;
+
+        return $this;
+    }
+
+    /**
      * @param string $scheme
      * @return self
      */

--- a/src/Config/RequestDefaults.php
+++ b/src/Config/RequestDefaults.php
@@ -78,12 +78,23 @@ class RequestDefaults
     }
 
     /**
-     * Set to true enable SSL certificate verification
+     * Disable SSL certification verification.
+     *
      * @return self
      */
-    public function disableSsl(): self
+    public function disableSslVerification(): self
     {
         return $this->addRequestOption(self::VERIFY, false);
+    }
+
+    /**
+     * Enable SSL certificate verification.
+     *
+     * @return $this
+     */
+    public function enableSslVerification(): self
+    {
+        return $this->addRequestOption(self::VERIFY, true);
     }
 
     /**

--- a/test/Unit/Config/ApiContextTest.php
+++ b/test/Unit/Config/ApiContextTest.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types=1);
+
+namespace SupportPal\ApiClient\Tests\Unit\Config;
+
+use PHPUnit\Framework\TestCase;
+use SupportPal\ApiClient\Config\ApiContext;
+
+class ApiContextTest extends TestCase
+{
+    private const HOST = 'localhost';
+
+    private const TOKEN = 'testtoken';
+
+    /** @var ApiContext */
+    private $apiContext;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->apiContext = new ApiContext(self::HOST, self::TOKEN);
+    }
+
+    public function testToken(): void
+    {
+        $this->assertSame(self::TOKEN, $this->apiContext->getApiToken());
+    }
+
+    /**
+     * @param ApiContext $apiContext
+     * @param string $expected
+     * @dataProvider provideGetApiUrlCases
+     */
+    public function testGetApiUrl(ApiContext $apiContext, string $expected): void
+    {
+        $this->assertSame($expected, $apiContext->getApiUrl());
+    }
+
+    /**
+     * @param ApiContext $apiContext
+     * @param string $expected
+     * @dataProvider provideGetApiPathCases
+     */
+    public function testGetApiPath(ApiContext $apiContext, string $expected): void
+    {
+        $this->assertSame($expected, $apiContext->getApiPath());
+    }
+
+    public function testDisableSsl(): void
+    {
+        $apiContext = (new ApiContext(self::HOST, self::TOKEN))->setPort(443)->setScheme('https');
+        $this->assertSame('https://localhost:443/api/', $apiContext->getApiUrl());
+        $apiContext->disableSsl();
+        $this->assertSame('http://localhost:80/api/', $apiContext->getApiUrl());
+    }
+
+    public function testEnableSsl(): void
+    {
+        $apiContext = (new ApiContext(self::HOST, self::TOKEN))->setPort(80)->setScheme('http');
+        $this->assertSame('http://localhost:80/api/', $apiContext->getApiUrl());
+        $apiContext->enableSsl();
+        $this->assertSame('https://localhost:443/api/', $apiContext->getApiUrl());
+    }
+
+    /**
+     * @return iterable<array<int, string|ApiContext>>
+     */
+    public function provideGetApiUrlCases(): iterable
+    {
+        $apiContext = (new ApiContext(self::HOST, self::TOKEN))->enableSsl()->setPath('/test/');
+
+        yield [$apiContext, 'https://localhost:443/test/api/'];
+
+        $apiContext = (new ApiContext(self::HOST, self::TOKEN))->enableSsl()->setPath('//test/test//');
+
+        yield [$apiContext, 'https://localhost:443/test/test/api/'];
+
+        $apiContext = (new ApiContext(self::HOST, self::TOKEN))->disableSsl()->setPath('//test/test//');
+
+        yield [$apiContext, 'http://localhost:80/test/test/api/'];
+
+        $apiContext = (new ApiContext(self::HOST, self::TOKEN));
+
+        yield [$apiContext, 'https://localhost:443/api/'];
+
+        $apiContext = (new ApiContext(self::HOST, self::TOKEN))->setPort(555);
+
+        yield [$apiContext, 'https://localhost:555/api/'];
+
+        $apiContext = (new ApiContext(self::HOST, self::TOKEN))->setScheme('ftp');
+
+        yield [$apiContext, 'ftp://localhost:443/api/'];
+    }
+
+    /**
+     * @return iterable<array<int, string|ApiContext>>
+     */
+    public function provideGetApiPathCases(): iterable
+    {
+        $apiContext = (new ApiContext(self::HOST, self::TOKEN))->setPath('/test/');
+
+        yield [$apiContext, '/test/api/'];
+
+        $apiContext = (new ApiContext(self::HOST, self::TOKEN))->setPath('//test/test//');
+
+        yield [$apiContext, '/test/test/api/'];
+
+        $apiContext = (new ApiContext(self::HOST, self::TOKEN));
+
+        yield [$apiContext, '/api/'];
+    }
+}


### PR DESCRIPTION
The API context currently defaults to `https` connections.

If you want to switch to `http` you have to:
```php
$context->setScheme('http')->setPort(80);
```

This is somewhat tedious and unnecessary:
1. The scheme is always either `http` or `https` so this abstraction (`setScheme`) is unnecessary
2. In the vast majority of situations the help desk is available on the world wide web (either port `80` / `443`) rather than some custom port.

This PR simplifies this use case to:
```php
$context->disableSsl();
```

I've also changed `disableSsl` in the `RequestDefaults` to `disableSslVerification` in order to prevent confusion. One pertains to the the URI, the other to request verification.