### PR TITLE
feat: renamed getSettings to all

### DIFF
--- a/src/Model/SettingsModel.php
+++ b/src/Model/SettingsModel.php
@@ -15,4 +15,11 @@ interface SettingsModel extends Model
      * @return string[]
      */
     public function all(): array;
+
+    /**
+     * @param string $name
+     * @param null $default
+     * @return string|null
+     */
+    public function get(string $name, $default = null): ?string;
 }

--- a/src/Model/SettingsModel.php
+++ b/src/Model/SettingsModel.php
@@ -14,5 +14,5 @@ interface SettingsModel extends Model
     /**
      * @return string[]
      */
-    public function getSettings(): array;
+    public function all(): array;
 }

--- a/src/Model/Shared/Settings.php
+++ b/src/Model/Shared/Settings.php
@@ -32,7 +32,7 @@ class Settings implements SettingsModel
     /**
      * @inheritDoc
      */
-    public function getSettings(): array
+    public function all(): array
     {
         return $this->settings;
     }

--- a/src/Model/Shared/Settings.php
+++ b/src/Model/Shared/Settings.php
@@ -21,12 +21,11 @@ class Settings implements SettingsModel
     }
 
     /**
-     * @param string $name
-     * @return string|null
+     * @inheritDoc
      */
-    public function getSetting(string $name): ?string
+    public function get(string $name, $default = null): ?string
     {
-        return $this->settings[$name] ?? null;
+        return $this->settings[$name] ?? $default;
     }
 
     /**

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -105,7 +105,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
                 $this->assertArrayEqualsObjectFields($object, $data['data'][$offset]);
             }
         } elseif ($models instanceof SettingsModel) {
-            $this->assertSame($models->getSettings(), $data['data']);
+            $this->assertSame($models->all(), $data['data']);
         } else {
             $this->assertArrayEqualsObjectFields($models, $data['data']);
         }

--- a/test/Unit/Model/Shared/SettingsTest.php
+++ b/test/Unit/Model/Shared/SettingsTest.php
@@ -14,7 +14,7 @@ class SettingsTest extends TestCase
         $model = $this->getModel();
         $modelData = $this->getModelData();
         $model->fill($modelData);
-        $this->assertSame($model->getSettings(), $modelData);
+        $this->assertSame($model->all(), $modelData);
     }
 
     /**


### PR DESCRIPTION
Consider:
```php
$api = new SupportPal(new ApiContext('example.com', 'foo'));

$settings = $api->getCoreApi()->getSettings()->getSettings();
```

This isn't very easy to understand, why is `getSettings` being called twice. This PR changes it to:


```php
$api = new SupportPal(new ApiContext('example.com', 'foo'));

$settings = $api->getCoreApi()->getSettings()->all();
```

`toArray` may also be suitable instead of `all`