### PR TITLE
fix: nullable order attribute on custom field options

### DIFF
--- a/src/Model/Shared/Option.php
+++ b/src/Model/Shared/Option.php
@@ -20,7 +20,7 @@ class Option extends BaseModel
     private $createdAt;
 
     /**
-     * @var int
+     * @var int|null
      * @SerializedName("order")
      */
     private $order;
@@ -88,18 +88,18 @@ class Option extends BaseModel
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getOrder(): int
+    public function getOrder(): ?int
     {
         return $this->order;
     }
 
     /**
-     * @param int $order
+     * @param int|null $order
      * @return self
      */
-    public function setOrder(int $order): self
+    public function setOrder(?int $order): self
     {
         $this->order = $order;
 


### PR DESCRIPTION
The order column on all `*_option` tables is nullable:
```sql
CREATE TABLE `user_customfield_option` (
 `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
 `field_id` int(10) unsigned NOT NULL,
 `order` int(10) unsigned DEFAULT NULL,
 `value` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
 `created_at` int(11) NOT NULL,
 `updated_at` int(11) NOT NULL DEFAULT 0,
 PRIMARY KEY (`id`),
 KEY `user_customfield_option_field_id_foreign` (`field_id`),
 CONSTRAINT `user_customfield_option_field_id_foreign` FOREIGN KEY (`field_id`) REFERENCES `user_customfield` (`id`) ON DELETE CASCADE
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
```