### PR TITLE
fix: id attribute missing from SlaPlan model

### DIFF
--- a/src/Model/Ticket/SlaPlan.php
+++ b/src/Model/Ticket/SlaPlan.php
@@ -8,6 +8,12 @@ use Symfony\Component\Serializer\Annotation\SerializedName;
 class SlaPlan extends BaseModel
 {
     /**
+     * @var int|null
+     * @SerializedName("id")
+     */
+    private $id;
+
+    /**
      * @var int
      * @SerializedName("condition_group_type")
      */
@@ -48,6 +54,25 @@ class SlaPlan extends BaseModel
      * @SerializedName("name")
      */
     private $name;
+
+    /**
+     * @return int|null
+     */
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int|null $id
+     * @return self
+     */
+    public function setId(?int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
 
     /**
      * @return int


### PR DESCRIPTION
I haven't bothered to identify the steps required to replicate this but it occurs when submitting a ticket and also when viewing `supporttickets.php`. The error is fairly obvious, `SlaPlan` does not have an `id` attribute defined and so the type extractor is returning no data.

```
TypeError: array_filter() expects parameter 1 to be array, null given in /home/kieran/Websites/whmcs8/modules/support/supportpal/vendor/supportpal/api-client-php/src/Transformer/IntToBooleanTransformer.php:54
Stack trace:
#0 /home/kieran/Websites/whmcs8/modules/support/supportpal/vendor/supportpal/api-client-php/src/Transformer/IntToBooleanTransformer.php(54): array_filter(NULL, Object(Closure))
#1 /home/kieran/Websites/whmcs8/modules/support/supportpal/vendor/supportpal/api-client-php/src/Transformer/IntToBooleanTransformer.php(30): SupportPal\ApiClient\Transformer\IntToBooleanTransformer->isBoolAttribute('SupportPal\\ApiC...', 'id')
#2 /home/kieran/Websites/whmcs8/modules/support/supportpal/vendor/supportpal/api-client-php/src/Normalizer/ModelNormalizer.php(108): SupportPal\ApiClient\Transformer\IntToBooleanTransformer->canTransform('id', 'SupportPal\\ApiC...', 1)
#3 /home/kieran/Websites/whmcs8/modules/support/supportpal/vendor/supportpal/api-client-php/src/Normalizer/ModelNormalizer.php(58): SupportPal\ApiClient\Normalizer\ModelNormalizer->applyAttributeAwareTransformations(Array, 'SupportPal\\ApiC...')
#4 /home/kieran/Websites/whmcs8/modules/support/supportpal/vendor/symfony/serializer/Serializer.php(205): SupportPal\ApiClient\Normalizer\ModelNormalizer->denormalize(Array, 'SupportPal\\ApiC...', 'json', Array)
#5 /home/kieran/Websites/whmcs8/modules/support/supportpal/vendor/symfony/serializer/Normalizer/AbstractObjectNormalizer.php(423): Symfony\Component\Serializer\Serializer->denormalize(Array, 'SupportPal\\ApiC...', 'json', Array)
#6 /home/kieran/Websites/whmcs8/modules/support/supportpal/vendor/symfony/serializer/Normalizer/AbstractObjectNormalizer.php(332): Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer->validateAndDenormalize('SupportPal\\ApiC...', 'slaplan', Array, 'json', Array)
#7 /home/kieran/Websites/whmcs8/modules/support/supportpal/vendor/supportpal/api-client-php/src/Normalizer/ModelNormalizer.php(60): Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer->denormalize(Array, 'SupportPal\\ApiC...', 'json', Array)
#8 /home/kieran/Websites/whmcs8/modules/support/supportpal/vendor/symfony/serializer/Serializer.php(205): SupportPal\ApiClient\Normalizer\ModelNormalizer->denormalize(Array, 'SupportPal\\ApiC...', 'json', Array)
#9 /home/kieran/Websites/whmcs8/modules/support/supportpal/vendor/symfony/serializer/Serializer.php(144): Symfony\Component\Serializer\Serializer->denormalize(Array, 'SupportPal\\ApiC...', 'json', Array)
#10 /home/kieran/Websites/whmcs8/modules/support/supportpal/vendor/supportpal/api-client-php/src/Factory/BaseModelFactory.php(50): Symfony\Component\Serializer\Serializer->deserialize(Array, 'SupportPal\\ApiC...', 'json')
#11 /home/kieran/Websites/whmcs8/modules/support/supportpal/vendor/supportpal/api-client-php/src/Factory/ModelCollectionFactory.php(46): SupportPal\ApiClient\Factory\BaseModelFactory->create(Array)
#12 /home/kieran/Websites/whmcs8/modules/support/supportpal/vendor/supportpal/api-client-php/src/Api/Ticket/TicketApis.php(96): SupportPal\ApiClient\Factory\ModelCollectionFactory->create('SupportPal\\ApiC...', Array)
#13 [internal function]: SupportPal\ApiClient\Api\TicketApi->createTicket(Array)
#14 /home/kieran/Websites/whmcs8/modules/support/supportpal/vendor/supportpal/api-client-php/src/Api/Ticket/TicketApis.php(31): array_map(Array, Array)
#15 /home/kieran/Websites/whmcs8/modules/support/supportpal/Repository/Ticket/TicketRepository.php(41): SupportPal\ApiClient\Api\TicketApi->getTickets(Array)
#16 /home/kieran/Websites/whmcs8/modules/support/supportpal/Controller/Ticket/TicketGridController.php(194): SupportPal\WhmcsIntegration\Repository\Ticket\TicketRepository->findBy(Array)
#17 /home/kieran/Websites/whmcs8/modules/support/supportpal/supporttickets.php(24): SupportPal\WhmcsIntegration\Controller\Ticket\TicketGridController->index(Object(Symfony\Component\HttpFoundation\Request))
#18 /home/kieran/Websites/whmcs8/supporttickets.php(0): unknown()
#19 {main}
```

```php
    protected function isBoolAttribute(string $class, string $attribute)
    {
        /** @var Type[] $types */
        $types = $this->propertyTypeExtractor->getTypes($class, $attribute);
        if (is_null($types)) {
            var_dump($types, $class, $attribute);
            /*
             * NULL, 'SupportPal\ApiClient\Model\Ticket\SlaPlan', 'id'
             */
            die;
        }
```
