### PR TITLE
feat: create api context from url

### DIFF
--- a/src/Config/ApiContext.php
+++ b/src/Config/ApiContext.php
@@ -2,6 +2,10 @@
 
 namespace SupportPal\ApiClient\Config;
 
+use SupportPal\ApiClient\Exception\InvalidArgumentException;
+
+use function array_key_exists;
+use function parse_url;
 use function sprintf;
 use function trim;
 
@@ -105,5 +109,40 @@ class ApiContext
     private function trim(string $str): string
     {
         return trim($str, '/');
+    }
+
+    /**
+     * Create an API context from a url.
+     *
+     * @param string $url
+     * @param string $token
+     * @return static
+     * @throws InvalidArgumentException
+     */
+    public static function createFromUrl(string $url, string $token): self
+    {
+        $components = parse_url($url);
+        if (! isset($components['host'])) {
+            throw new InvalidArgumentException('URL is missing a hostname component.');
+        }
+
+        $scheme = $components['scheme'] ?? null;
+        $port   = $components['port'] ?? ($scheme === 'http' ? 80 : null);
+
+        $apiContext = new ApiContext($components['host'], $token);
+
+        if ($port !== null) {
+            $apiContext->setPort($port);
+        }
+
+        if (array_key_exists('path', $components)) {
+            $apiContext->setPath($components['path']);
+        }
+
+        if ($scheme !== null) {
+            $apiContext->setScheme($components['scheme']);
+        }
+
+        return $apiContext;
     }
 }

--- a/src/Config/ApiContext.php
+++ b/src/Config/ApiContext.php
@@ -4,7 +4,6 @@ namespace SupportPal\ApiClient\Config;
 
 use SupportPal\ApiClient\Exception\InvalidArgumentException;
 
-use function array_key_exists;
 use function parse_url;
 use function sprintf;
 use function trim;
@@ -142,18 +141,19 @@ class ApiContext
      *
      * @param string $url
      * @param string $token
-     * @return static
+     * @return self
      * @throws InvalidArgumentException
      */
     public static function createFromUrl(string $url, string $token): self
     {
-        $components = parse_url($url);
+        $components = (array) parse_url($url);
         if (! isset($components['host'])) {
             throw new InvalidArgumentException('URL is missing a hostname component.');
         }
 
         $scheme = $components['scheme'] ?? null;
-        $port   = $components['port'] ?? ($scheme === 'http' ? 80 : null);
+        $port   = $components['port'] ?? ($scheme === 'http' ? 80 : null) ?? ($scheme === 'https' ? 443 : null);
+        $path   = $components['path'] ?? null;
 
         $apiContext = new ApiContext($components['host'], $token);
 
@@ -161,12 +161,12 @@ class ApiContext
             $apiContext->setPort($port);
         }
 
-        if (array_key_exists('path', $components)) {
-            $apiContext->setPath($components['path']);
+        if ($path !== null) {
+            $apiContext->setPath($path);
         }
 
         if ($scheme !== null) {
-            $apiContext->setScheme($components['scheme']);
+            $apiContext->setScheme($scheme);
         }
 
         return $apiContext;

--- a/test/Unit/Config/ApiContextTest.php
+++ b/test/Unit/Config/ApiContextTest.php
@@ -4,6 +4,7 @@ namespace SupportPal\ApiClient\Tests\Unit\Config;
 
 use PHPUnit\Framework\TestCase;
 use SupportPal\ApiClient\Config\ApiContext;
+use SupportPal\ApiClient\Exception\InvalidArgumentException;
 
 class ApiContextTest extends TestCase
 {
@@ -62,6 +63,18 @@ class ApiContextTest extends TestCase
     }
 
     /**
+     * @param string $url
+     * @param string $expected
+     * @throws InvalidArgumentException
+     * @dataProvider provideCreateFromUrlCases
+     */
+    public function testCreateFromUrl(string $url, string $expected): void
+    {
+        $apiContext = ApiContext::createFromUrl($url, self::TOKEN);
+        $this->assertSame($expected, $apiContext->getApiUrl());
+    }
+
+    /**
      * @return iterable<array<int, string|ApiContext>>
      */
     public function provideGetApiUrlCases(): iterable
@@ -107,5 +120,21 @@ class ApiContextTest extends TestCase
         $apiContext = (new ApiContext(self::HOST, self::TOKEN));
 
         yield [$apiContext, '/api/'];
+    }
+
+    /**
+     * @return iterable<array<int, string>>
+     */
+    public function provideCreateFromUrlCases(): iterable
+    {
+        yield ['http://localhost/test/test/', 'http://localhost:80/test/test/api/'];
+        yield ['http://localhost/test/test/api/', 'http://localhost:80/test/test/api/api/'];
+        yield ['https://localhost:443/test/test/api/', 'https://localhost:443/test/test/api/api/'];
+        yield ['https://localhost:443/test/test/api//', 'https://localhost:443/test/test/api/api/'];
+        yield ['https://localhost', 'https://localhost:443/api/'];
+        yield ['https://localhost', 'https://localhost:443/api/'];
+        yield ['ftp://localhost', 'ftp://localhost:443/api/'];
+        yield ['http://localhost', 'http://localhost:80/api/'];
+        yield ['http://localhost:5550', 'http://localhost:5550/api/'];
     }
 }


### PR DESCRIPTION
This will save people a lot of heart ache. 

The WHMCS integration is a prime example where we have a URL and need to initialise the client. This occurs in two places:
1. initialisation of all api calls
2. validate.php

Very similar code is also used in the test suite... a lot of duplication that could be included in this library.