### PR TITLE
fix: skip conversion for non-identified types

### DIFF
--- a/src/Exception/UndefinedPropertyException.php
+++ b/src/Exception/UndefinedPropertyException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace SupportPal\ApiClient\Exception;
+
+use Exception;
+
+class UndefinedPropertyException extends Exception
+{
+}

--- a/src/Exception/UndefinedPropertyException.php
+++ b/src/Exception/UndefinedPropertyException.php
@@ -1,9 +1,0 @@
-<?php declare(strict_types=1);
-
-namespace SupportPal\ApiClient\Exception;
-
-use Exception;
-
-class UndefinedPropertyException extends Exception
-{
-}

--- a/src/Transformer/IntToBooleanTransformer.php
+++ b/src/Transformer/IntToBooleanTransformer.php
@@ -2,6 +2,7 @@
 
 namespace SupportPal\ApiClient\Transformer;
 
+use SupportPal\ApiClient\Exception\UndefinedPropertyException;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
 
@@ -9,6 +10,7 @@ use function array_filter;
 use function boolval;
 use function in_array;
 use function is_int;
+use function sprintf;
 
 class IntToBooleanTransformer implements AttributeAwareTransformer
 {
@@ -42,17 +44,22 @@ class IntToBooleanTransformer implements AttributeAwareTransformer
      * @param string $class
      * @param string $attribute
      * @return bool
+     * @throws UndefinedPropertyException
      */
     protected function isBoolAttribute(string $class, string $attribute)
     {
-        /** @var Type[] $types */
+        /** @var Type[]|null $types */
         $types = $this->propertyTypeExtractor->getTypes($class, $attribute);
-        $boolFilteredType = array_filter(
-            $types,
-            function (Type $type) {
-                return $type->getBuiltinType() === Type::BUILTIN_TYPE_BOOL;
-            }
-        );
+
+        if ($types === null) {
+            throw new UndefinedPropertyException(
+                sprintf('Unable to determine type of attribute %s of class %s', $class, $attribute)
+            );
+        }
+
+        $boolFilteredType = array_filter($types, function (Type $type) {
+            return $type->getBuiltinType() === Type::BUILTIN_TYPE_BOOL;
+        });
 
         return ! empty($boolFilteredType);
     }

--- a/src/Transformer/IntToBooleanTransformer.php
+++ b/src/Transformer/IntToBooleanTransformer.php
@@ -2,7 +2,6 @@
 
 namespace SupportPal\ApiClient\Transformer;
 
-use SupportPal\ApiClient\Exception\UndefinedPropertyException;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
 
@@ -10,7 +9,6 @@ use function array_filter;
 use function boolval;
 use function in_array;
 use function is_int;
-use function sprintf;
 
 class IntToBooleanTransformer implements AttributeAwareTransformer
 {
@@ -44,18 +42,11 @@ class IntToBooleanTransformer implements AttributeAwareTransformer
      * @param string $class
      * @param string $attribute
      * @return bool
-     * @throws UndefinedPropertyException
      */
     protected function isBoolAttribute(string $class, string $attribute)
     {
-        /** @var Type[]|null $types */
-        $types = $this->propertyTypeExtractor->getTypes($class, $attribute);
-
-        if ($types === null) {
-            throw new UndefinedPropertyException(
-                sprintf('Unable to determine type of attribute %s of class %s', $class, $attribute)
-            );
-        }
+        /** @var Type[] $types */
+        $types = $this->propertyTypeExtractor->getTypes($class, $attribute) ?? [];
 
         $boolFilteredType = array_filter($types, function (Type $type) {
             return $type->getBuiltinType() === Type::BUILTIN_TYPE_BOOL;

--- a/test/Unit/Transformer/IntToBooleanTransformerTest.php
+++ b/test/Unit/Transformer/IntToBooleanTransformerTest.php
@@ -104,8 +104,9 @@ class IntToBooleanTransformerTest extends TestCase
             ->getTypes(Model::class, $this->attribute)
             ->shouldBeCalled()
             ->willReturn(null);
-        $this->expectException(UndefinedPropertyException::class);
-        $this->intToBooleanTransformer->canTransform($this->attribute, Model::class, 1);
+
+        $value = $this->intToBooleanTransformer->canTransform($this->attribute, Model::class, 1);
+        $this->assertSame(false, $value);
     }
 
     /**

--- a/test/Unit/Transformer/IntToBooleanTransformerTest.php
+++ b/test/Unit/Transformer/IntToBooleanTransformerTest.php
@@ -4,6 +4,7 @@ namespace SupportPal\ApiClient\Tests\Unit\Transformer;
 
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
+use SupportPal\ApiClient\Exception\UndefinedPropertyException;
 use SupportPal\ApiClient\Model\Model;
 use SupportPal\ApiClient\Model\SelfService\Comment;
 use SupportPal\ApiClient\Tests\TestCase;
@@ -95,6 +96,16 @@ class IntToBooleanTransformerTest extends TestCase
     public function testTransform(int $data, bool $expected): void
     {
         $this->assertSame($expected, $this->intToBooleanTransformer->transform($data));
+    }
+
+    public function testCannotDetermineAttributeType(): void
+    {
+        $this->propertyTypeExtractor
+            ->getTypes(Model::class, $this->attribute)
+            ->shouldBeCalled()
+            ->willReturn(null);
+        $this->expectException(UndefinedPropertyException::class);
+        $this->intToBooleanTransformer->canTransform($this->attribute, Model::class, 1);
     }
 
     /**

--- a/test/Unit/Transformer/IntToBooleanTransformerTest.php
+++ b/test/Unit/Transformer/IntToBooleanTransformerTest.php
@@ -4,7 +4,6 @@ namespace SupportPal\ApiClient\Tests\Unit\Transformer;
 
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
-use SupportPal\ApiClient\Exception\UndefinedPropertyException;
 use SupportPal\ApiClient\Model\Model;
 use SupportPal\ApiClient\Model\SelfService\Comment;
 use SupportPal\ApiClient\Tests\TestCase;


### PR DESCRIPTION
When type extractor cannot identify the type, process and empty array so the SDK doesn't crash.

This fixes the following issue:
```
ERROR: TypeError: array_filter() expects parameter 1 to be array, null given in / supportpal/api-client-php/src/Transformer/IntToBooleanTransformer.php:54 Stack trace: #0
```
