### PR TITLE
chore(deps): updated supportpal/coding-standard to v0.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "rregeer/phpunit-coverage-check": "^0.3.1",
     "slevomat/coding-standard": "^6.4",
     "squizlabs/php_codesniffer": "^3.5",
-    "supportpal/coding-standard": "^0.2"
+    "supportpal/coding-standard": "^0.3"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Nothing special in this. `else if` will raise an error when previously it didn't. This change doesn't affect this library.