### PR TITLE
fix: use response reason phrase for non-json responses

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -88,7 +88,7 @@ class ApiClient
             $body = $this->decoder->decode((string) $response->getBody(), $this->formatType);
         } catch (NotEncodableValueException $notEncodableValueException) {
             throw new HttpResponseException(
-                $notEncodableValueException->getMessage(),
+                $response->getReasonPhrase(),
                 $notEncodableValueException->getCode(),
                 $notEncodableValueException
             );

--- a/test/Integration/ApiClientTest.php
+++ b/test/Integration/ApiClientTest.php
@@ -53,10 +53,10 @@ class ApiClientTest extends ContainerAwareBaseTestCase
     public function testResponseNonEncodeableException(): void
     {
         $request = new Request('GET', 'test');
-        $this->appendRequestResponse(new Response(200, [], ''));
+        $this->appendRequestResponse(new Response(404, [], ''));
 
         $this->expectException(HttpResponseException::class);
-        $this->expectExceptionMessage('Syntax error');
+        $this->expectExceptionMessage('Not Found');
         $this->apiClient->sendRequest($request);
     }
 

--- a/test/Unit/ApiClientTest.php
+++ b/test/Unit/ApiClientTest.php
@@ -91,6 +91,7 @@ class ApiClientTest extends TestCase
         $this->expectException(HttpResponseException::class);
         $request = $this->prophesize(RequestInterface::class);
         $response = $this->prophesize(ResponseInterface::class);
+        $response->getReasonPhrase()->shouldBeCalled()->willReturn('');
 
         $this
             ->httpClient


### PR DESCRIPTION
Nonencodeable exception will almost always return an error related to the parsing operation instead of the API response. This changes the behaviour to fetch the error from the response.