### PR TITLE
ci: enable semantic commits in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,16 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit_message:
+      prefix: "fix"
+      prefix_development: "chore"
+      include_scope: true
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
+    commit_message:
+      prefix: "fix"
+      prefix_development: "chore"
+      include_scope: true


### PR DESCRIPTION
Hopefully this enables semantic commits for dependabot updates, ref: https://dependabot.com/docs/config-file/#commit_message