### PR TITLE
ci: fix dependabot.yml syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,16 +5,16 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    commit_message:
+    commit-message:
       prefix: "fix"
-      prefix_development: "chore"
-      include_scope: true
+      prefix-development: "chore"
+      include: "scope"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
-    commit_message:
+    commit-message:
       prefix: "fix"
-      prefix_development: "chore"
-      include_scope: true
+      prefix-development: "chore"
+      include: "scope"


### PR DESCRIPTION
In classic fashion it turned out https://github.com/supportpal/api-client-php/pull/80 is the wrong syntax

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#commit-message is the correct syntax