### PR TITLE
fix: add phpdocumentor production dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "doctrine/cache": "^1.10",
     "guzzlehttp/guzzle": "^7.0",
     "kevinrob/guzzle-cache-middleware": "^3.3",
+    "phpdocumentor/reflection-docblock": "^5.2",
     "psr/http-message": "^1.0",
     "symfony/config": "^5.1",
     "symfony/dependency-injection": "^5.1",


### PR DESCRIPTION
When running the SDK in production mode, the following exception would be thrown:
```
PHP Fatal error:  Uncaught LogicException: Unable to use the "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor" class as the "phpdocumentor/reflection-docblock" package is not installed. in /Users/ghaith/Documents/work_projects/SupportPal/supportpal-sdk/vendor/symfony/property-info/Extractor/PhpDocExtractor.php:63
```

This dependency was not met when installing production dependencies only. This behaviour is masked by phpunit requiring the same dependency in dev mode.