### PR TITLE
fix: composer distribution file exclusions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,14 @@
-.gitattributes export-ignore
-.gitignore export-ignore
-/composer.json export-ignore
-/phpstan.neon export-ignore
-/phpcs.xml export-ignore
-/phpunit.dist.xml export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
 /.github export-ignore
+/.releaserc export-ignore
 /ci export-ignore
-/test export-ignore
+/composer.json export-ignore
 /ModelParser export-ignore
-.releaserc export-ignore
-package.json export-ignore
-package-lock.json
+/package.json export-ignore
+/package-lock.json export-ignore
+/phpcs.xml export-ignore
+/phpmd.xml export-ignore
+/phpstan.neon export-ignore
+/phpunit.xml.dist export-ignore
+/test export-ignore


### PR DESCRIPTION
* sorted the file alphabetically
* fixed `phpunit.dist.xml` reference, file is actually called `phpunit.xml.dist`
* fixed `package-lock.json` reference - missing `export-ignore`
* added new exclusions for `phpmd.xml` 