### PR TITLE
fix: invalid department id type hint

### DIFF
--- a/src/Model/Department/Email.php
+++ b/src/Model/Department/Email.php
@@ -26,7 +26,7 @@ class Email extends BaseModel
     private $port;
 
     /**
-     * @var int
+     * @var int|string
      * @SerializedName("department_id")
      */
     private $departmentId;
@@ -158,7 +158,7 @@ class Email extends BaseModel
      */
     public function getDepartmentId(): int
     {
-        return $this->departmentId;
+        return (int) $this->departmentId;
     }
 
     /**


### PR DESCRIPTION
This PR adds 'string' type hint to Email. 

This is necessary because of the type validation pass the serializer does before committing the value through the setter.

The newly added type hint  just tells the serializer to expect a string, however we're enforcing that this string has a valid value in the setter.