### PR TITLE
fix: update department default assigned type hint

### DIFF
--- a/src/Model/Department/Department.php
+++ b/src/Model/Department/Department.php
@@ -98,7 +98,7 @@ class Department extends BaseModel
     private $notifyOperators;
 
     /**
-     * @var Operator[]
+     * @var string[]
      * @SerializedName("default_assignedto")
      */
     private $defaultAssignedto;
@@ -422,7 +422,7 @@ class Department extends BaseModel
     }
 
     /**
-     * @return Operator[]
+     * @return string[]
      */
     public function getDefaultAssignedto(): array
     {
@@ -430,7 +430,7 @@ class Department extends BaseModel
     }
 
     /**
-     * @param Operator[] $defaultAssignedto
+     * @param string[] $defaultAssignedto
      * @return self
      */
     public function setDefaultAssignedto(array $defaultAssignedto): self


### PR DESCRIPTION
On the main helpdesk, the return of `default_assigned_to` attribute is an array of operators ID. the JSON response includes ids of operators instead of operators object, this PR corrects the type hint.

```
ERROR: TypeError: Argument 1 passed to SupportPal\\ApiClient\\Normalizer\\ModelNormalizer::applyAttributeAwareTransformations() must be of the type array, string given
...
 ```