### PR TITLE
fix: unable to overwrite request defaults

### DIFF
--- a/src/Factory/RequestFactory.php
+++ b/src/Factory/RequestFactory.php
@@ -92,7 +92,7 @@ class RequestFactory
     ): RequestInterface {
         $headers['Content-Type'] = $headers['Content-Type'] ?? $this->contentType;
         $headers['Authorization'] = $headers['Authorization'] ?? 'Basic ' . base64_encode($this->apiToken . ':X');
-        $bodyArray = array_merge($body, $this->defaultBodyContent);
+        $bodyArray = array_merge($this->defaultBodyContent, $body);
 
         $body = ! empty($bodyArray) ? Utils::streamFor($this->encoder->encode($bodyArray, $this->formatType)) : null;
 
@@ -100,7 +100,7 @@ class RequestFactory
 
         return new Request(
             $method,
-            $uri->withQuery(http_build_query(array_merge($queryParameters, $this->defaultParameters))),
+            $uri->withQuery(http_build_query(array_merge($this->defaultParameters, $queryParameters))),
             $headers,
             $body
         );


### PR DESCRIPTION
This PR updates the order of variables in `array_merge` to overwrite values from the default values if also supplied in the function parameters.

> If the input arrays have the same string keys, then the later value for that key will overwrite the previous one. 
https://www.php.net/manual/en/function.array-merge.php