### PR TITLE
fix: set same data for request body and query for all requests

### DIFF
--- a/src/Config/RequestDefaults.php
+++ b/src/Config/RequestDefaults.php
@@ -20,24 +20,18 @@ class RequestDefaults
     private $defaultParameters;
 
     /** @var array<mixed> */
-    private $defaultBodyContent;
-
-    /** @var array<mixed> */
     private $defaultRequestOptions;
 
     /**
      * RequestDefaults constructor.
      * @param array<mixed> $defaultParameters
-     * @param array<mixed> $defaultBodyContent
      * @param array<mixed> $defaultRequestOptions
      */
     public function __construct(
         array $defaultParameters = [],
-        array $defaultBodyContent = [],
         array $defaultRequestOptions = self::DEFAULT_OPTIONS
     ) {
         $this->defaultParameters = $defaultParameters;
-        $this->defaultBodyContent = $defaultBodyContent;
         $this->defaultRequestOptions = $defaultRequestOptions;
     }
 
@@ -50,11 +44,13 @@ class RequestDefaults
     }
 
     /**
+     * @deprecated Use getDefaultParameters instead, to be removed in 2.0.0.
+     *
      * @return array<mixed>
      */
     public function getDefaultBodyContent(): array
     {
-        return $this->defaultBodyContent;
+        return $this->defaultParameters;
     }
 
     /**
@@ -77,12 +73,14 @@ class RequestDefaults
     }
 
     /**
+     * @deprecated Use setDefaultParameters instead, to be removed in 2.0.0.
+     *
      * @param array<mixed> $defaultBodyContent
      * @return self
      */
     public function setDefaultBodyContent(array $defaultBodyContent): self
     {
-        $this->defaultBodyContent = $defaultBodyContent;
+        $this->defaultParameters = $defaultBodyContent;
 
         return $this;
     }

--- a/src/Resources/factories.yml
+++ b/src/Resources/factories.yml
@@ -10,7 +10,6 @@ services:
             $apiUrl: '%apiUrl%'
             $apiToken: '%apiToken%'
             $contentType: '%apiContentType%'
-            $defaultBodyContent: '%defaultBodyContent%'
             $defaultParameters: '%defaultParameters%'
             $formatType: '%contentType%'
 

--- a/src/SupportPal.php
+++ b/src/SupportPal.php
@@ -57,7 +57,6 @@ class SupportPal
         $containerBuilder->setParameter('apiUrl', $apiContext->getApiUrl());
         $containerBuilder->setParameter('apiToken', $apiContext->getApiToken());
         $containerBuilder->setParameter('defaultParameters', $requestDefaults->getDefaultParameters());
-        $containerBuilder->setParameter('defaultBodyContent', $requestDefaults->getDefaultBodyContent());
 
         $containerBuilder->set(
             Client::class,

--- a/test/Integration/Factory/RequestFactoryTest.php
+++ b/test/Integration/Factory/RequestFactoryTest.php
@@ -28,9 +28,6 @@ class RequestFactoryTest extends ContainerAwareBaseTestCase
     private $apiContentType;
 
     /** @var array<mixed> */
-    private $defaultBodyContent;
-
-    /** @var array<mixed> */
     private $defaultParameters;
 
     public function setUp(): void
@@ -41,7 +38,6 @@ class RequestFactoryTest extends ContainerAwareBaseTestCase
         $this->requestFactory = $requestFactory;
         $this->apiToken = $this->getContainer()->getParameter('apiToken');
         $this->apiContentType = $this->getContainer()->getParameter('apiContentType');
-        $this->defaultBodyContent = $this->getContainer()->getParameter('defaultBodyContent');
         $this->defaultParameters = $this->getContainer()->getParameter('defaultParameters');
     }
 
@@ -75,8 +71,8 @@ class RequestFactoryTest extends ContainerAwareBaseTestCase
 
         $headersArray['Host'] = [$request->getUri()->getHost() . ':' . $request->getUri()->getPort()];
 
-        $encodedBody = ! empty($data['body']) || ! empty($this->defaultBodyContent)
-            ? $this->getEncoder()->encode(array_merge($data['body'], $this->defaultBodyContent), $this->getFormatType())
+        $encodedBody = ! empty($data['body']) || ! empty($this->defaultParameters)
+            ? $this->getEncoder()->encode(array_merge($data['body'], $this->defaultParameters), $this->getFormatType())
             : '';
 
         self::assertInstanceOf(Request::class, $request);

--- a/test/Resources/services_test.yml
+++ b/test/Resources/services_test.yml
@@ -23,7 +23,6 @@ services:
             $apiUrl: '%apiUrl%'
             $apiToken: '%apiToken%'
             $contentType: '%apiContentType%'
-            $defaultBodyContent: '%defaultBodyContent%'
             $defaultParameters: '%defaultParameters%'
             $formatType: '%contentType%'
 


### PR DESCRIPTION
Noticed an issue when trying to test https://github.com/supportpal/api-client-php/pull/107 that the `query` and `body` data on the request could be different if a value was overwritten. As there should no cases where we need to send different data for these two options, it's best to make it consistent and ensure the same data is sent for both.