### PR TITLE
feat: add array data to factory exception

### DIFF
--- a/src/Exception/InvalidDataException.php
+++ b/src/Exception/InvalidDataException.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace SupportPal\ApiClient\Exception;
+
+use Throwable;
+
+class InvalidDataException extends InvalidArgumentException
+{
+    /** @var array<mixed> */
+    private $data;
+
+    /**
+     * InvalidDataException constructor.
+     * @param array<mixed> $data
+     * @param string $message
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(array $data, string $message = '', int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->data = $data;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Factory/BaseModelFactory.php
+++ b/src/Factory/BaseModelFactory.php
@@ -3,7 +3,7 @@
 namespace SupportPal\ApiClient\Factory;
 
 use Exception;
-use SupportPal\ApiClient\Exception\InvalidArgumentException;
+use SupportPal\ApiClient\Exception\InvalidDataException;
 use SupportPal\ApiClient\Model\Model;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -50,10 +50,11 @@ abstract class BaseModelFactory implements ModelFactory
                 $this->formatType
             );
         } catch (Exception $invalidArgumentException) {
-            throw new InvalidArgumentException(
+            throw new InvalidDataException(
+                $data,
                 $invalidArgumentException->getMessage(),
                 $invalidArgumentException->getCode(),
-                $invalidArgumentException->getPrevious()
+                $invalidArgumentException
             );
         }
 

--- a/src/Factory/ModelFactory.php
+++ b/src/Factory/ModelFactory.php
@@ -2,7 +2,7 @@
 
 namespace SupportPal\ApiClient\Factory;
 
-use SupportPal\ApiClient\Exception\InvalidArgumentException;
+use SupportPal\ApiClient\Exception\InvalidDataException;
 use SupportPal\ApiClient\Model\Model;
 
 /**
@@ -14,7 +14,7 @@ interface ModelFactory
     /**
      * This method creates an instance of a SupportPalModel
      * @param array<mixed> $data
-     * @throws InvalidArgumentException
+     * @throws InvalidDataException
      * @return Model
      */
     public function create(array $data): Model;


### PR DESCRIPTION
In the case of having an issue with model deserialization, the data causing the issue can be lost. To have better logs, this PR adds the data into the thrown exception so SDK users would be able to log the data causing the issue.