### PR TITLE
fix: incorrect category translation attribute

### DIFF
--- a/src/Model/SelfService/CategoryTranslation.php
+++ b/src/Model/SelfService/CategoryTranslation.php
@@ -15,9 +15,9 @@ class CategoryTranslation extends BaseTranslation
 
     /**
      * @var int
-     * @SerializedName("type_id")
+     * @SerializedName("category_id")
      */
-    private $typeId;
+    private $categoryId;
 
     /**
      * @var string
@@ -51,20 +51,22 @@ class CategoryTranslation extends BaseTranslation
     }
 
     /**
+     * @deprecated
      * @return int
      */
     public function getTypeId(): int
     {
-        return $this->typeId;
+        return $this->categoryId;
     }
 
     /**
-     * @param int $typeId
+     * @deprecated
+     * @param int $categoryId
      * @return self
      */
-    public function setTypeId(int $typeId): self
+    public function setTypeId(int $categoryId): self
     {
-        $this->typeId = $typeId;
+        $this->categoryId = $categoryId;
 
         return $this;
     }
@@ -103,6 +105,25 @@ class CategoryTranslation extends BaseTranslation
     public function setDescription(string $description): self
     {
         $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCategoryId(): int
+    {
+        return $this->categoryId;
+    }
+
+    /**
+     * @param int $categoryId
+     * @return CategoryTranslation
+     */
+    public function setCategoryId(int $categoryId): self
+    {
+        $this->categoryId = $categoryId;
 
         return $this;
     }

--- a/src/Model/SelfService/CategoryTranslation.php
+++ b/src/Model/SelfService/CategoryTranslation.php
@@ -26,12 +26,6 @@ class CategoryTranslation extends BaseTranslation
     private $slug;
 
     /**
-     * @var string
-     * @SerializedName("description")
-     */
-    private $description;
-
-    /**
      * @return string
      */
     public function getName(): string
@@ -91,21 +85,22 @@ class CategoryTranslation extends BaseTranslation
     }
 
     /**
+     * Invalid property in the model, this getter will be removed in the next major release
+     * @deprecated
      * @return string
      */
-    public function getDescription(): string
+    public function getDescription(): ?string
     {
-        return $this->description;
+        return null;
     }
 
     /**
-     * @param string $description
+     * Invalid property in the model, this setter will be removed in the next major release
      * @return self
+     * @deprecated
      */
-    public function setDescription(string $description): self
+    public function setDescription(): self
     {
-        $this->description = $description;
-
         return $this;
     }
 

--- a/test/DataFixtures/SelfService/CategoryTranslationData.php
+++ b/test/DataFixtures/SelfService/CategoryTranslationData.php
@@ -8,7 +8,7 @@ use SupportPal\ApiClient\Tests\DataFixtures\BaseModelData;
 class CategoryTranslationData extends BaseModelData
 {
     public const DATA = [
-        'type_id' => 2,
+        'category_id' => 2,
         'name' => 'test',
         'slug' => 'test',
         'description' => 'test',

--- a/test/DataFixtures/SelfService/CategoryTranslationData.php
+++ b/test/DataFixtures/SelfService/CategoryTranslationData.php
@@ -11,8 +11,7 @@ class CategoryTranslationData extends BaseModelData
         'category_id' => 2,
         'name' => 'test',
         'slug' => 'test',
-        'description' => 'test',
-        'locale' => 'ar'
+        'locale' => 'ar',
     ];
 
     /**

--- a/test/Unit/Model/Collection/CollectionTest.php
+++ b/test/Unit/Model/Collection/CollectionTest.php
@@ -158,7 +158,7 @@ class CollectionTest extends TestCase
     }
 
     /**
-     * @return Comment[]
+     * @return Model[]
      * @throws InvalidArgumentException
      */
     private function getModelsTestData(): array


### PR DESCRIPTION
Calling `{server}/api/selfservice/category` returns the category response  reply:
```
...
            "translations": [
                {
                    "category_id": 1,
                    "name": "test",
                    "slug": "test",
                    "locale": "en"
                }
...
 ```
 
 The property `type_id`  is not valid in the context of category_translation and would throw an error when denormalizing the object. 
 
 This PR  replaces the incorrect attribute.