### PR TITLE
chore: use prefer-lowest instead of prefer-stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,8 @@ jobs:
             fail-fast: true
             matrix:
                 php: [7.2, 7.3, 7.4, 8.0]
-                stability: [prefer-stable]
 
-        name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
+        name: PHP ${{ matrix.php }}
 
         steps:
             - name: Checkout code
@@ -29,7 +28,7 @@ jobs:
               uses: StephaneBour/actions-php-cpd@7.4
 
             - name: Install dependencies
-              run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+              run: composer install --prefer-dist --no-interaction --no-progress
 
             - name: Code Standard and Static Analysis
               run: ci/analyse.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,9 @@ jobs:
             fail-fast: true
             matrix:
                 php: [7.2, 7.3, 7.4, 8.0]
+                stability: [prefer-stable]
 
-        name: PHP ${{ matrix.php }}
+        name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
 
         steps:
             - name: Checkout code
@@ -28,7 +29,7 @@ jobs:
               uses: StephaneBour/actions-php-cpd@7.4
 
             - name: Install dependencies
-              run: composer install --prefer-dist --no-interaction --no-progress
+              run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
             - name: Code Standard and Static Analysis
               run: ci/analyse.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
             fail-fast: true
             matrix:
                 php: [7.2, 7.3, 7.4, 8.0]
-                stability: [prefer-stable]
+                stability: [prefer-lowest]
 
         name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "brianium/paratest": "^4.0|^5.0|^6.0",
     "larapack/dd": "^1.1",
     "phpmd/phpmd": "^2.9",
-    "phpstan/phpstan": "0.12.69",
+    "phpstan/phpstan": "^0.12.42",
     "phpunit/phpunit": "^8.0|^9.0",
     "rregeer/phpunit-coverage-check": "^0.3.1",
     "slevomat/coding-standard": "^6.4",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "brianium/paratest": "^4.0|^5.0|^6.0",
     "larapack/dd": "^1.1",
     "phpmd/phpmd": "^2.9",
-    "phpstan/phpstan": "^0.12.42",
+    "phpstan/phpstan": "0.12.69",
     "phpunit/phpunit": "^8.0|^9.0",
     "rregeer/phpunit-coverage-check": "^0.3.1",
     "slevomat/coding-standard": "^6.4",


### PR DESCRIPTION
We're receiving inconsistent CI results without actually changing anything, evident in:
* https://github.com/supportpal/api-client-php/pull/120
* https://github.com/supportpal/api-client-php/pull/119

This is due to the use of `--prefer-stable` when running `composer update` to install dependencies for each PHP version.

In the case of the referenced PRs `symfony/dependency-injection` changed a docblock from `mixed` to `string|[..]` - see:
* https://github.com/symfony/dependency-injection/blob/v5.2.1/Container.php#L112
* https://github.com/symfony/dependency-injection/blob/v5.2.2/Container.php#L112

This then causes PHPStan to complain that the return type is no longer `string` it can be anything.