### PR TITLE
test: handle new getParameter return types

### DIFF
--- a/test/ContainerAwareBaseTestCase.php
+++ b/test/ContainerAwareBaseTestCase.php
@@ -147,7 +147,7 @@ abstract class ContainerAwareBaseTestCase extends TestCase
      */
     protected function getFormatType(): string
     {
-        return $this->container->getParameter('contentType');
+        return (string) $this->container->getParameter('contentType');
     }
 
     /**

--- a/test/Integration/Factory/RequestFactoryTest.php
+++ b/test/Integration/Factory/RequestFactoryTest.php
@@ -39,10 +39,10 @@ class RequestFactoryTest extends ContainerAwareBaseTestCase
         /** @var RequestFactory $requestFactory */
         $requestFactory = $this->getContainer()->get(RequestFactory::class);
         $this->requestFactory = $requestFactory;
-        $this->apiToken = $this->getContainer()->getParameter('apiToken');
-        $this->apiContentType = $this->getContainer()->getParameter('apiContentType');
-        $this->defaultBodyContent = $this->getContainer()->getParameter('defaultBodyContent');
-        $this->defaultParameters = $this->getContainer()->getParameter('defaultParameters');
+        $this->apiToken = (string) $this->getContainer()->getParameter('apiToken');
+        $this->apiContentType = (string) $this->getContainer()->getParameter('apiContentType');
+        $this->defaultBodyContent = (array) $this->getContainer()->getParameter('defaultBodyContent');
+        $this->defaultParameters = (array) $this->getContainer()->getParameter('defaultParameters');
     }
 
     /**


### PR DESCRIPTION
Fix PHPStan errors which occur due to changes in `symfony/dependency-injection` `v5.2.2`:
* https://github.com/symfony/dependency-injection/blob/v5.2.1/Container.php#L112
* https://github.com/symfony/dependency-injection/blob/v5.2.2/Container.php#L112