### PR TITLE
feat: add simple interface to add attachments

### DIFF
--- a/src/Model/Ticket/Request/CreateMessage.php
+++ b/src/Model/Ticket/Request/CreateMessage.php
@@ -2,6 +2,7 @@
 
 namespace SupportPal\ApiClient\Model\Ticket\Request;
 
+use SupportPal\ApiClient\Exception\InvalidArgumentException;
 use SupportPal\ApiClient\Model\BaseModel;
 use Symfony\Component\Serializer\Annotation\SerializedName;
 
@@ -68,7 +69,7 @@ class CreateMessage extends BaseModel
     private $sendOperatorsEmail;
 
     /**
-     * @var string[]|null
+     * @var array<string[]>|null
      * @SerializedName("attachment")
      */
     private $attachment;
@@ -245,7 +246,7 @@ class CreateMessage extends BaseModel
     }
 
     /**
-     * @return string[]|null
+     * @return array<string[]>|null
      */
     public function getAttachment(): ?array
     {
@@ -253,12 +254,31 @@ class CreateMessage extends BaseModel
     }
 
     /**
-     * @param string[]|null $attachment
+     * This method expects an array of attachments in the following format.
+     * ['filename' => 'test', 'contents' => 'some-base-64-string'].
+     * This method overwrites any attachments you previously set.
+     * @param array<string[]>|null $attachments
      * @return self
+     * @throws InvalidArgumentException
      */
-    public function setAttachment(?array $attachment): self
+    public function setAttachment(?array $attachments): self
     {
-        $this->attachment = $attachment;
+        if ($attachments !== null) {
+            foreach ($attachments as $attachment) {
+                if (! isset($attachment['filename']) || ! isset($attachment['contents'])) {
+                    throw new InvalidArgumentException('Each Attachment value must include a file name, and contents.');
+                }
+            }
+        }
+
+        $this->attachment = $attachments;
+
+        return $this;
+    }
+
+    public function addAttachment(string $fileName, string $contents): self
+    {
+        $this->attachment[] = ['filename' => $fileName, 'contents' => $contents];
 
         return $this;
     }

--- a/src/Model/Ticket/Request/CreateMessage.php
+++ b/src/Model/Ticket/Request/CreateMessage.php
@@ -2,7 +2,6 @@
 
 namespace SupportPal\ApiClient\Model\Ticket\Request;
 
-use SupportPal\ApiClient\Exception\InvalidArgumentException;
 use SupportPal\ApiClient\Model\BaseModel;
 use Symfony\Component\Serializer\Annotation\SerializedName;
 
@@ -256,21 +255,13 @@ class CreateMessage extends BaseModel
     /**
      * This method expects an array of attachments in the following format.
      * ['filename' => 'test', 'contents' => 'some-base-64-string'].
+     * If the array is supplied using an incorrect format the attachment will be ignored.
      * This method overwrites any attachments you previously set.
      * @param array<string[]>|null $attachments
      * @return self
-     * @throws InvalidArgumentException
      */
     public function setAttachment(?array $attachments): self
     {
-        if ($attachments !== null) {
-            foreach ($attachments as $attachment) {
-                if (! isset($attachment['filename']) || ! isset($attachment['contents'])) {
-                    throw new InvalidArgumentException('Each Attachment value must include a file name, and contents.');
-                }
-            }
-        }
-
         $this->attachment = $attachments;
 
         return $this;

--- a/test/Unit/Model/Ticket/Request/CreateMessageTest.php
+++ b/test/Unit/Model/Ticket/Request/CreateMessageTest.php
@@ -2,7 +2,6 @@
 
 namespace SupportPal\ApiClient\Tests\Unit\Model\Ticket\Request;
 
-use SupportPal\ApiClient\Exception\InvalidArgumentException;
 use SupportPal\ApiClient\Model\Model;
 use SupportPal\ApiClient\Model\Ticket\Request\CreateMessage;
 use SupportPal\ApiClient\Tests\DataFixtures\Ticket\Request\CreateMessageData;
@@ -29,14 +28,5 @@ class CreateMessageTest extends BaseModelTestCase
     protected function getModel(): Model
     {
         return new CreateMessage;
-    }
-
-    public function testAddAttachmentWithIncorrectData(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $modelData = $this->getModelData();
-        $modelData['attachment'] = ['test_invalid_data'];
-
-        $this->getModel()->fill($modelData);
     }
 }

--- a/test/Unit/Model/Ticket/Request/CreateMessageTest.php
+++ b/test/Unit/Model/Ticket/Request/CreateMessageTest.php
@@ -2,6 +2,7 @@
 
 namespace SupportPal\ApiClient\Tests\Unit\Model\Ticket\Request;
 
+use SupportPal\ApiClient\Exception\InvalidArgumentException;
 use SupportPal\ApiClient\Model\Model;
 use SupportPal\ApiClient\Model\Ticket\Request\CreateMessage;
 use SupportPal\ApiClient\Tests\DataFixtures\Ticket\Request\CreateMessageData;
@@ -28,5 +29,14 @@ class CreateMessageTest extends BaseModelTestCase
     protected function getModel(): Model
     {
         return new CreateMessage;
+    }
+
+    public function testAddAttachmentWithIncorrectData(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $modelData = $this->getModelData();
+        $modelData['attachment'] = ['test_invalid_data'];
+
+        $this->getModel()->fill($modelData);
     }
 }


### PR DESCRIPTION
This PR closes #134 by adding a simpler interface to adding attachments to the create message request and adds documentation to `setAttachment` method.

Attachments to messages now can be added either through:
```
$attachments = [
    ['filename' => 'test', 'contents' => 'base-64-string',],
    ['filename' => 'test2', 'contents' => 'base-64-string-2',]
 ];
$createMessage = (new CreateMessage)->fill(['ticket_id' => 1, 'user_id' => 1, 'text' => 'Message', 'attachment' => $attachments]);
$message = $api->getTicketApi()->postMessage(createMessage);
```

or by adding them one by one.

```
$attachments = [
    ['filename' => 'test', 'contents' => 'base-64-string',],
    ['filename' => 'test2', 'contents' => 'base-64-string-2',]
 ];
$createMessage = (new CreateMessage)->fill(['ticket_id' => 1, 'user_id' => 1, 'text' => 'Message', ]);
foreach ($attachments as $fileName => $contents) {
    $createMessage->addAttachment($fileName, $contents)
}
$message = $api->getTicketApi()->postMessage(createMessage);
```

Given that using `setAttachment` would overwrite any previously added attachments.