### PR TITLE
fix: type translation slug can also be null

### DIFF
--- a/src/Model/SelfService/TypeTranslation.php
+++ b/src/Model/SelfService/TypeTranslation.php
@@ -26,7 +26,7 @@ class TypeTranslation extends BaseTranslation
     private $description;
 
     /**
-     * @var string
+     * @var string|null
      * @SerializedName("slug")
      */
     private $slug;
@@ -89,18 +89,18 @@ class TypeTranslation extends BaseTranslation
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getSlug(): string
+    public function getSlug(): ?string
     {
         return $this->slug;
     }
 
     /**
-     * @param string $slug
+     * @param string|null $slug
      * @return self
      */
-    public function setSlug(string $slug): self
+    public function setSlug(?string $slug): self
     {
         $this->slug = $slug;
 


### PR DESCRIPTION
Fixes:
```
`The type of the "slug" attribute for class "SupportPal\WhmcsIntegration\Vendor\SupportPal\ApiClient\Model\SelfService\TypeTranslation" must be one of "string" ("null" given).`
```

This can occur if you add a translation to an external link type. It now matches the same as the main type model.