### PR TITLE
chore(deps): lock phpstan/phpstan to 1.10.25

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "larapack/dd": "^1.1",
     "phpmd/phpmd": "^2.9",
     "phpspec/prophecy-phpunit": "^1.1|^2.0",
-    "phpstan/phpstan": "^1.0",
+    "phpstan/phpstan": "1.10.25",
     "phpunit/phpunit": "^8.0|^9.0",
     "rregeer/phpunit-coverage-check": "^0.3.1",
     "slevomat/coding-standard": "^6.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c3162137af7735a631e708be8a8bbac",
+    "content-hash": "f6f33d44fd5fbaf4d4e88f72aa9edaac",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -3601,16 +3601,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.3",
+            "version": "1.10.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "5419375b5891add97dc74be71e6c1c34baaddf64"
+                "reference": "578f4e70d117f9a90699324c555922800ac38d8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/5419375b5891add97dc74be71e6c1c34baaddf64",
-                "reference": "5419375b5891add97dc74be71e6c1c34baaddf64",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/578f4e70d117f9a90699324c555922800ac38d8c",
+                "reference": "578f4e70d117f9a90699324c555922800ac38d8c",
                 "shasum": ""
             },
             "require": {
@@ -3639,8 +3639,11 @@
                 "static analysis"
             ],
             "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.10.3"
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
             },
             "funding": [
                 {
@@ -3656,7 +3659,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-25T14:47:13+00:00"
+            "time": "2023-07-06T12:11:37+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/src/Model/SettingsModel.php
+++ b/src/Model/SettingsModel.php
@@ -7,7 +7,7 @@ interface SettingsModel extends Model
     /**
      * @param mixed $property
      * @param mixed $value
-     * @return self
+     * @return void
      */
     public function __set($property, $value);
 

--- a/src/Model/Shared/Settings.php
+++ b/src/Model/Shared/Settings.php
@@ -16,8 +16,6 @@ class Settings implements SettingsModel
     public function __set($property, $value)
     {
         $this->settings[$property] = $value;
-
-        return $this;
     }
 
     /**


### PR DESCRIPTION
CI runs: `composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress` which when using semantic versioning results in PHPStan being upgraded from the version in the lock file. PHPStan analysis tends to change every version so it's best if we lock it and manually upgrade, otherwise we're in a constantly battle fixing broken CI pipelines.