### PR TITLE
Fix deprecation notice

### DIFF
--- a/test/ContainerAwareBaseTestCase.php
+++ b/test/ContainerAwareBaseTestCase.php
@@ -87,9 +87,7 @@ abstract class ContainerAwareBaseTestCase extends TestCase
          */
         $reflectionClass = new ReflectionObject($this->supportPal);
         $property = $reflectionClass->getProperty('containerBuilder');
-        $property->setAccessible(true);
         $property->setValue($this->supportPal, $containerBuilder);
-        $property->setAccessible(false);
 
         $this->container = $containerBuilder;
     }


### PR DESCRIPTION
```
PHP Deprecated:  Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in /home/runner/work/api-client-php/api-client-php/test/ContainerAwareBaseTestCase.php on line 90
```